### PR TITLE
Rewrite ebook links (local vs. external)

### DIFF
--- a/src/app/components/Application/Application.jsx
+++ b/src/app/components/Application/Application.jsx
@@ -4,10 +4,12 @@ import { withRouter } from 'react-router';
 
 import { Header, navConfig } from '@nypl/dgx-header-component';
 import Footer from '@nypl/dgx-react-footer';
+import appConfig from '../../../../appConfig';
 
 class Application extends React.Component {
   constructor(props) {
     super(props);
+    this.props = props;
   }
 
   render() {
@@ -30,6 +32,7 @@ Application.propTypes = {
   location: PropTypes.object,
   history: PropTypes.object,
   children: PropTypes.object,
+  eReaderUrl: PropTypes.string,
 };
 
 Application.defaultProps = {
@@ -37,9 +40,10 @@ Application.defaultProps = {
   location: {},
   history: {},
   children: {},
+  eReaderUrl: appConfig.ereader[process.env.APP_ENV],
 };
 
-Application.contextType = {
+Application.contextTypes = {
   router: PropTypes.object,
 };
 

--- a/src/app/components/List/EBookList.jsx
+++ b/src/app/components/List/EBookList.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
-import appConfig from '../../../../appConfig';
-
-const ebookUrl = appConfig.ereader[process.env.APP_ENV];
+import PropTypes from 'prop-types';
 
 /**
- * Create a link defaulting to a ebook "download" unless
+ * Create a link defaulting to an ebook "download" unless
  * the ebook is hosted by us (link has our S3 bucket pattern)
  * which shows a link to our eReader with the S3 bucket URL as
  * a query parameter.
+ * NOTE: Project Gutenberg, I believe, has an initial cookie set
+ * before you can directly download items. So if no cookie exists,
+ * you're directed to their site first which can be confusing.
  * @param {string} url
  * @return {string}
  */
-const generateLink = (url) => {
+const generateLink = (url, eReaderUrl) => {
   let link = `${url}`;
   let linkText = 'Download';
 
-  if (url.includes('simplye')) {
-    link = `${ebookUrl}?url=${url}`;
+  if (url && url.includes('simplye')) {
+    link = `${eReaderUrl}?url=${url}`;
     linkText = 'Read Online';
   }
 
@@ -25,16 +26,20 @@ const generateLink = (url) => {
   );
 };
 
-const EBookList = (ebooks) => {
+const EBookList = (props) => {
   return (
     <ul className="nypl-items-list">
-      {ebooks.ebooks.map((ebook, ebookKey) => (
+      {props.ebooks.map((ebook, ebookKey) => (
         <li key={ebookKey.toString()}>
-          {generateLink(ebook.url)} [{ebook.epub_path.split('/').pop()}]
+          {generateLink(ebook.url, props.eReaderUrl)} {(ebook.epub_path) ? [ebook.epub_path.split('/').pop()] : ''}
         </li>
       ))}
     </ul>
   );
+};
+
+EBookList.contextTypes = {
+  eReaderUrl: PropTypes.string,
 };
 
 export default EBookList;

--- a/src/app/components/List/EBookList.jsx
+++ b/src/app/components/List/EBookList.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 /**
  * Create a link defaulting to an ebook "download" unless
@@ -36,10 +35,6 @@ const EBookList = (props) => {
       ))}
     </ul>
   );
-};
-
-EBookList.contextTypes = {
-  eReaderUrl: PropTypes.string,
 };
 
 export default EBookList;

--- a/src/app/components/List/EBookList.jsx
+++ b/src/app/components/List/EBookList.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import appConfig from '../../../../appConfig';
+
+const ebookUrl = appConfig.ereader[process.env.APP_ENV];
+
+/**
+ * Create a link defaulting to a ebook "download" unless
+ * the ebook is hosted by us (link has our S3 bucket pattern)
+ * which shows a link to our eReader with the S3 bucket URL as
+ * a query parameter.
+ * @param {string} url
+ * @return {string}
+ */
+const generateLink = (url) => {
+  let link = `${url}`;
+  let linkText = 'Download';
+
+  if (url.includes('simplye')) {
+    link = `${ebookUrl}?url=${url}`;
+    linkText = 'Read Online';
+  }
+
+  return (
+    <a href={`${link}`}>{`${linkText}`}</a>
+  );
+};
+
+const EBookList = (ebooks) => {
+  return (
+    <ul className="nypl-items-list">
+      {ebooks.ebooks.map((ebook, ebookKey) => (
+        <li key={ebookKey.toString()}>
+          {generateLink(ebook.url)} [{ebook.epub_path.split('/').pop()}]
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default EBookList;

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -8,18 +8,21 @@ import SearchResults from '../SearchResults/SearchResults';
 import * as searchActions from '../../actions/SearchActions';
 
 class SearchContainer extends React.Component {
-  constructor(props) {
+  constructor(props, context) {
     super(props);
     const { dispatch } = props;
 
     this.boundActions = bindActionCreators(searchActions, dispatch);
     this.showingDetails = false;
+    this.context = context;
+    this.setState = (props, context);
   }
 
   componentDidUpdate() {
     const updated = true;
     this.showingDetails = updated;
   }
+
 
   render() {
     return (
@@ -41,6 +44,7 @@ class SearchContainer extends React.Component {
             />
             <SearchResults
               results={this.props.searchResults}
+              eReaderUrl={this.props.eReaderUrl}
               {...this.boundActions}
             />
           </div>
@@ -56,6 +60,7 @@ SearchContainer.propTypes = {
   searchField: PropTypes.string,
   workDetail: PropTypes.object,
   dispatch: PropTypes.func,
+  eReaderUrl: PropTypes.string,
 };
 
 SearchContainer.defaultProps = {
@@ -64,6 +69,7 @@ SearchContainer.defaultProps = {
   searchField: 'q',
   workDetail: {},
   dispatch: () => {},
+  eReaderUrl: PropTypes.string,
 };
 
 SearchContainer.contextTypes = {

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -67,7 +67,7 @@ SearchContainer.defaultProps = {
   searchField: 'q',
   workDetail: {},
   dispatch: () => {},
-  eReaderUrl: PropTypes.string,
+  eReaderUrl: '',
 };
 
 SearchContainer.contextTypes = {

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -8,14 +8,12 @@ import SearchResults from '../SearchResults/SearchResults';
 import * as searchActions from '../../actions/SearchActions';
 
 class SearchContainer extends React.Component {
-  constructor(props, context) {
+  constructor(props) {
     super(props);
     const { dispatch } = props;
 
     this.boundActions = bindActionCreators(searchActions, dispatch);
     this.showingDetails = false;
-    this.context = context;
-    this.setState = (props, context);
   }
 
   componentDidUpdate() {

--- a/src/app/components/SearchResults/ResultsList.jsx
+++ b/src/app/components/SearchResults/ResultsList.jsx
@@ -23,25 +23,30 @@ class ResultsList extends React.Component {
       this.props.fetchWork(workId);
       this.context.router.push(`/work?workId=${workId}`);
     };
+    console.log(this.props.results);
 
     return (
       <div>
-        <h2>Works</h2>
+        <h2>Search Results</h2>
         <ul className="nypl-results-list">
           {this.props.results.map((result, i) => (
               <li className="nypl-results-item" key={i.toString()}>
                 <h3>
                   <Link onClick={event => showWorkDetail(event, result['_source'].uuid)} to={{ pathname: '/work', query: { workId: `${result['_source'].uuid}` } }}>
-                    {result['_source'].title} &ndash; {result['_source'].entities[0].name}
+                    {result['_source'].title}{(result['_source'].entities && Array.isArray(result['_source'].entities)) ? ` – ${result['_source'].entities[0].name}` : ''}
                   </Link>
                 </h3>
-                <ResultsRow rows={result['_source'].instances} />
+                <ResultsRow rows={result['_source'].instances} eReaderUrl={this.props.eReaderUrl} />
               </li>
             ))}
         </ul>
       </div>
     );
   }
+}
+
+ResultsList.propTypes = {
+  eReaderUrl: PropTypes.string,
 }
 
 ResultsList.contextTypes = {

--- a/src/app/components/SearchResults/ResultsList.jsx
+++ b/src/app/components/SearchResults/ResultsList.jsx
@@ -49,8 +49,4 @@ ResultsList.propTypes = {
   eReaderUrl: PropTypes.string,
 }
 
-ResultsList.contextTypes = {
-  router: PropTypes.object,
-};
-
 export default ResultsList;

--- a/src/app/components/SearchResults/ResultsList.jsx
+++ b/src/app/components/SearchResults/ResultsList.jsx
@@ -23,7 +23,6 @@ class ResultsList extends React.Component {
       this.props.fetchWork(workId);
       this.context.router.push(`/work?workId=${workId}`);
     };
-    console.log(this.props.results);
 
     return (
       <div>
@@ -47,6 +46,14 @@ class ResultsList extends React.Component {
 
 ResultsList.propTypes = {
   eReaderUrl: PropTypes.string,
-}
+};
+
+ResultsList.defaultProps = {
+  eReaderUrl: '',
+};
+
+ResultsList.contextTypes = {
+  router: PropTypes.object,
+};
 
 export default ResultsList;

--- a/src/app/components/SearchResults/ResultsMetadata.jsx
+++ b/src/app/components/SearchResults/ResultsMetadata.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-const ResultsMetadata = (metadata) => {
+const ResultsMetadata = (props) => {
   let message = 'Your search yielded no results. Please try again.';
 
-  if (metadata.metadata.total > 0) {
-    message = `Displaying 1 - ${metadata.metadata.total < 10 ? metadata.metadata.total : 10} of ${metadata.metadata.total} ; Relevancy score: ${metadata.metadata.max_score}`;
+  if (props.metadata.total > 0) {
+    message = `Displaying 1 - ${props.metadata.total < 10 ? props.metadata.total : 10} of ${props.metadata.total} ; Relevancy score: ${props.metadata.max_score}`;
   }
 
   return (

--- a/src/app/components/SearchResults/ResultsRow.jsx
+++ b/src/app/components/SearchResults/ResultsRow.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
   isEmpty as _isEmpty,
 } from 'underscore';
@@ -36,10 +35,6 @@ const ResultsRow = (props) => {
       }
     </ul>
   );
-};
-
-ResultsRow.contextTypes = {
-  router: PropTypes.object,
 };
 
 export default ResultsRow;

--- a/src/app/components/SearchResults/ResultsRow.jsx
+++ b/src/app/components/SearchResults/ResultsRow.jsx
@@ -1,15 +1,16 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   isEmpty as _isEmpty,
 } from 'underscore';
 import EBookList from '../List/EBookList';
 
-const ResultsRow = (rows) => {
-  if (_isEmpty(rows.rows)) {
+const ResultsRow = (props) => {
+  if (_isEmpty(props.rows)) {
     return null;
   }
 
-  const items = rows.rows.map(item => (
+  const items = props.rows.map(item => (
     {
       ebooks: (item.items) ? item.items : [],
       pub_date: (item.pub_date) ? parseInt(item.pub_date) : null,
@@ -24,7 +25,7 @@ const ResultsRow = (rows) => {
         items.map((element, key) => (
           <li className="nypl-results-item" key={key.toString()}>
             <div className="nypl-results-description">
-              <EBookList ebooks={element.ebooks} />
+              {(element.ebooks) ? <EBookList ebooks={element.ebooks} eReaderUrl={props.eReaderUrl} /> : ''}
               <span className="nypl-results-date">{element.pub_date}</span>
               <span className="nypl-results-place">{element.pub_place}</span>
               <span className="nypl-results-publisher">{element.publisher}</span>
@@ -35,6 +36,10 @@ const ResultsRow = (rows) => {
       }
     </ul>
   );
+};
+
+ResultsRow.contextTypes = {
+  router: PropTypes.object,
 };
 
 export default ResultsRow;

--- a/src/app/components/SearchResults/ResultsRow.jsx
+++ b/src/app/components/SearchResults/ResultsRow.jsx
@@ -2,14 +2,12 @@ import React from 'react';
 import {
   isEmpty as _isEmpty,
 } from 'underscore';
-import appConfig from '../../../../appConfig';
+import EBookList from '../List/EBookList';
 
 const ResultsRow = (rows) => {
   if (_isEmpty(rows.rows)) {
     return null;
   }
-  const appEnv = process.env.APP_ENV || 'production';
-  const eReaderUrl = `${appConfig.ereader[appEnv]}?url=`;
 
   const items = rows.rows.map(item => (
     {
@@ -17,31 +15,20 @@ const ResultsRow = (rows) => {
       pub_date: (item.pub_date) ? parseInt(item.pub_date) : null,
       pub_place: (item.pub_place) ? item.pub_place : null,
       publisher: (item.publisher) ? item.publisher : null,
-      language: (item.language) ? item.language : null,
     }
   ));
 
   return (
-    <ul className="nypl-item-list">
+    <ul className="nypl-items-list">
       {
         items.map((element, key) => (
           <li className="nypl-results-item" key={key.toString()}>
             <div className="nypl-results-description">
-              <ul className="nypl-ebooks-list">
-                {
-                  element.ebooks &&
-                  element.ebooks.map((ebook, ebookKey) => (
-                    <li className="nypl-results-media" key={ebookKey.toString()}>
-                      eBook: <a href={`${eReaderUrl}${ebook.url}`}> {ebook.url}</a>
-                    </li>
-                  ))
-                }
-                <br />
-                <span className="nypl-results-date">{element.pub_date}</span>
-                <span className="nypl-results-place">{element.pub_place}</span>
-                <span className="nypl-results-publisher">{element.publisher}</span>
-                <span className="nypl-results-info">{element.language}</span>
-              </ul>
+              <EBookList ebooks={element.ebooks} />
+              <span className="nypl-results-date">{element.pub_date}</span>
+              <span className="nypl-results-place">{element.pub_place}</span>
+              <span className="nypl-results-publisher">{element.publisher}</span>
+              <span className="nypl-results-info">{element.language}</span>
             </div>
           </li>
         ))

--- a/src/app/components/SearchResults/SearchResults.jsx
+++ b/src/app/components/SearchResults/SearchResults.jsx
@@ -15,11 +15,15 @@ const SearchResults = (props) => {
     <div className="nypl-row">
       <div className="nypl-column-full">
         <ResultsMetadata metadata={metadata} />
-        <ResultsList results={hits} fetchWork={props.fetchWork} />
+        <ResultsList results={hits} fetchWork={props.fetchWork} eReaderUrl={props.eReaderUrl} />
       </div>
     </div>
   );
 };
+
+SearchResults.propTypes = {
+  eReaderUrl: PropTypes.string,
+}
 
 SearchResults.contextType = {
   router: PropTypes.object,

--- a/src/app/components/SearchResults/SearchResults.jsx
+++ b/src/app/components/SearchResults/SearchResults.jsx
@@ -25,8 +25,4 @@ SearchResults.propTypes = {
   eReaderUrl: PropTypes.string,
 }
 
-SearchResults.contextType = {
-  router: PropTypes.object,
-};
-
 export default SearchResults;

--- a/src/app/components/SearchResults/SearchResults.jsx
+++ b/src/app/components/SearchResults/SearchResults.jsx
@@ -23,6 +23,10 @@ const SearchResults = (props) => {
 
 SearchResults.propTypes = {
   eReaderUrl: PropTypes.string,
-}
+};
+
+SearchResults.defaultProps = {
+  eReaderUrl: '',
+};
 
 export default SearchResults;

--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { isEmpty as _isEmpty } from 'underscore';
-import appConfig from '../../../../appConfig';
+import EBookList from '../List/EBookList';
 
-const ebookUrl = appConfig.ereader[process.env.APP_ENV];
 const elements = ['title', 'entities', 'instances', 'subjects', 'rights_stmt', 'language'];
 export const labels = {
   title: 'Title',
@@ -67,7 +66,7 @@ export const DefinitionList = (data) => {
             <tbody>
               {entries.map((instance, i) => (
                 <tr key={i.toString()}>
-                  <td>{(instance.items) ? parseEbooks(instance.items) : ''}</td>
+                  <td>{(instance.items) ? <EBookList ebooks={instance.items} /> : ''}</td>
                   <td>{instance.pub_date}</td>
                   <td>{(instance.pub_place) ? `Place of publication: ${instance.pub_place}` : ''}</td>
                   <td>{instance.publisher}</td>
@@ -80,23 +79,6 @@ export const DefinitionList = (data) => {
       default:
         return null;
     }
-  };
-
-  /**
-   * Generate an unordered list of links to ebooks (EPUBs) to our reader for locally
-   * stored EPUBs or a download link otherwise.
-   * @param {object} ebooks
-   */
-  const parseEbooks = (ebooks) => {
-    return (
-      <ul className="nypl-items-list">
-        {ebooks.map((ebook, i) => (
-            <li key={i.toString()}>
-            <a href={`${ebookUrl}?url=${ebook.url}`}>Read Online</a> [{ebook.epub_path.split('/').pop()}]<br />
-          </li>
-        ))}
-      </ul>
-    );
   };
 
   /**

--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -17,9 +17,9 @@ export const labels = {
 /**
  * Build a definition list of elements from a bibliographic record provided
  * by Elastisearch.
- * @param {array} data
+ * @param {object} props
  */
-export const DefinitionList = (data) => {
+export const DefinitionList = (props) => {
 
   /**
    * Handle elements with array values as definitions. Authorities are linked to
@@ -66,7 +66,7 @@ export const DefinitionList = (data) => {
             <tbody>
               {entries.map((instance, i) => (
                 <tr key={i.toString()}>
-                  <td>{(instance.items) ? <EBookList ebooks={instance.items} /> : ''}</td>
+                  <td>{(instance.items) ? <EBookList ebooks={instance.items} eReaderUrl={props.eReaderUrl} /> : ''}</td>
                   <td>{instance.pub_date}</td>
                   <td>{(instance.pub_place) ? `Place of publication: ${instance.pub_place}` : ''}</td>
                   <td>{instance.publisher}</td>
@@ -83,14 +83,14 @@ export const DefinitionList = (data) => {
 
   /**
    * Wrapper function to handle building the HTML from the object given.
-   * @param {object} details
+   * @param {array} data
    */
-  const getDefinitions = (details) => {
-    if (!details.data || _isEmpty(details.data)) {
+  const getDefinitions = (data) => {
+    if (!data || _isEmpty(data)) {
       return null;
     }
 
-    const detailsObject = details.data.map(entry => (
+    const detailsObject = data.map(entry => (
       {
         term: entry[0],
         definition: (Array.isArray(entry[1])) ? parseEntries(entry[0], entry[1]) : entry[1],
@@ -107,11 +107,12 @@ export const DefinitionList = (data) => {
     });
   };
 
-  return (<dl>{getDefinitions(data)}</dl>);
+  return (<dl>{getDefinitions(props.data)}</dl>);
 };
 
 DefinitionList.propTypes = {
   data: PropTypes.array,
+  eReaderUrl: PropTypes.string,
 };
 
 export default DefinitionList;

--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -115,4 +115,9 @@ DefinitionList.propTypes = {
   eReaderUrl: PropTypes.string,
 };
 
+DefinitionList.defaultProps = {
+  data: [],
+  eReaderUrl: '',
+};
+
 export default DefinitionList;

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -1,42 +1,59 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { DefinitionList } from './DefinitionList';
 
-const WorkDetail = (props) => {
-  if (!props.detail) {
-    return null;
+class WorkDetail extends React.Component {
+  constructor(props, context) {
+    super(props);
+    this.props = props;
+    this.context = context;
   }
-  const { detail } = props;
 
   /**
    * Convert JSON object to array for parsing detail elements into
    * a definition list for display.
    * @param {object} detailObject
    */
-  const itemDetailsObject = (detailObject) => {
+  itemDetailsObject(detailObject) {
     return Object.keys(detailObject.item).map(key => (
       [key, detailObject.item[key]]
     ));
   };
 
-  return (
-    <main id="mainContent">
-      <div className="nypl-page-header">
-        <div className="breadcrumb" />
-      </div>
-      <div className="nypl-full-width-wrapper">
-        <div className="nypl-row">
-          <div className="nypl-column-full">
-            <h2>Work Detail</h2>
-            <div id="nypl-item-details">
-              <DefinitionList data={itemDetailsObject(detail)} />
+  render() {
+    if (!this.props.detail) {
+      return null;
+    }
+    const { detail } = this.props;
+
+    return (
+      <main id="mainContent">
+        <div className="nypl-page-header">
+          <div className="breadcrumb" />
+        </div>
+        <div className="nypl-full-width-wrapper">
+          <div className="nypl-row">
+            <div className="nypl-column-full">
+              <h2>Work Detail</h2>
+              <div id="nypl-item-details">
+                <DefinitionList data={this.itemDetailsObject(detail)} eReaderUrl={this.props.eReaderUrl} />
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    </main>
-  );
+      </main>
+    );
+  }
+}
+
+WorkDetail.propTypes = {
+  eReaderUrl: PropTypes.string,
+};
+
+WorkDetail.defaultProps = {
+  eReaderUrl: '',
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/test/fixtures/results-list.json
+++ b/test/fixtures/results-list.json
@@ -13,7 +13,8 @@
           {
             "title": "Title One",
             "items": [{
-              "url": "http://localhost/epubs/epubOne.epub"
+              "url": "http://localhost/epubs/epubOne.epub",
+              "epub_path": "nypl.org/ebook/100.no.images"
             }],
             "pub_date": "511",
             "pub_place": "England",

--- a/test/unit/DefinitionList.test.js
+++ b/test/unit/DefinitionList.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { DefinitionList, labels } from '../../src/app/components/WorkDetail/DefinitionList';
+import EBookList from '../../src/app/components/List/EBookList';
 import { detail } from '../fixtures/work-detail.json';
 
 describe('DefinitionList', () => {
@@ -38,11 +39,23 @@ describe('DefinitionList', () => {
 
   it('should have a list of Subjects', () => {
     const subjects = component.find('ul');
-    expect(subjects.nodes[2].props.children).to.have.length(9);
+    expect(subjects.nodes[1].props.children).to.have.length(9);
   });
 
   it('should have a list of Authors', () => {
     const authors = component.find('ul');
-    expect(authors.nodes[1].props.children).to.have.length(2);
+    expect(authors.nodes[0].props.children).to.have.length(2);
+  });
+
+  describe('EBookList', () => {
+    before(() => {
+      const ebooks = detail.item.instances[0].items;
+      component = shallow(<EBookList ebooks={ebooks} />);
+    });
+    it('should have a list of two links', () => {
+      expect(component.find('ul')).to.have.length(1);
+      expect(component.find('li')).to.have.length(2);
+      expect(component.find('li a')).to.have.length(2);
+    });
   });
 });

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -26,7 +26,7 @@ describe('Results List', () => {
 
     it('should display a grouped list of works and their instances.', () => {
       expect(component.find('h2')).to.have.length(1);
-      expect(component.find('h2').text()).to.equal('Works');
+      expect(component.find('h2').text()).to.equal('Search Results');
       expect(component.find('.nypl-results-list')).to.have.length(1);
       expect(component.find('li')).to.have.length(2);
     });

--- a/test/unit/ResultsRow.test.js
+++ b/test/unit/ResultsRow.test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import ResultsRow from '../../src/app/components/SearchResults/ResultsRow';
 import { results } from '../fixtures/results-list.json';
+import EBookList from '../../src/app/components/List/EBookList';
 
 describe('ResultsRow', () => {
   let component;
@@ -14,12 +15,7 @@ describe('ResultsRow', () => {
     });
 
     it('should return row or rows of items', () => {
-      expect(component.find('.nypl-item-list')).to.have.length(1);
-    });
-
-    // Ebook item check
-    it('should contain ebook links', () => {
-      expect(component.find('.nypl-results-media').text()).to.equal('eBook: http://localhost/epubs/epubOne.epub');
+      expect(component.find('.nypl-items-list')).to.have.length(1);
     });
 
     // Publication date check
@@ -36,11 +32,6 @@ describe('ResultsRow', () => {
     it('should contain a publisher', () => {
       expect(component.find('.nypl-results-publisher').text()).to.equal('Merlin');
     });
-
-    // Language check
-    it('should contain a language', () => {
-      expect(component.find('.nypl-results-info').text()).to.equal('enm');
-    });
   });
 
   describe('Rows with partial item should render', () => {
@@ -49,12 +40,7 @@ describe('ResultsRow', () => {
     });
 
     it('should return row or rows of items', () => {
-      expect(component.find('.nypl-item-list')).to.have.length(1);
-    });
-
-    // Ebook item check
-    it('should not contain ebook links when not provided', () => {
-      expect(component.find('.nypl-results-media')).to.have.length(0);
+      expect(component.find('.nypl-items-list')).to.have.length(1);
     });
 
     // Publication date check
@@ -71,10 +57,17 @@ describe('ResultsRow', () => {
     it('should contain markup only when not provided', () => {
       expect(component.find('.nypl-results-publisher').text()).to.equal('');
     });
+  });
 
-    // Language check
-    it('should contain a language', () => {
-      expect(component.find('.nypl-results-info').text()).to.equal('enm');
+  describe('EBookList', () => {
+    before(() => {
+      const ebooks = results[0]['_source'].instances[0].items;
+      component = shallow(<EBookList ebooks={ebooks} />);
+    });
+    it('should have a list with a single line item with a single anchor tag', () => {
+      expect(component.find('.nypl-items-list')).to.have.length(1);
+      expect(component.find('.nypl-items-list li')).to.have.length(1);
+      expect(component.find('.nypl-items-list li a')).to.have.length(1);
     });
   });
 });


### PR DESCRIPTION
Adds list component for ebook links which need to show "Download" forexternally hosted ebooks and "Read Online" for locally hosted ebooks.

Attempts to fulfill requirements for [SFR-92](https://jira.nypl.org/browse/SFR-92) to provide a link to open an ebook in our local eReader if we host the ebook or a download link if the ebook is hosted externally.

Tests are included, but they are fairly brittle. Need to continue to work on shoring these up.