### PR TITLE
Title (field) search

### DIFF
--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -16,10 +16,10 @@ export const searchResults = (results) => {
   };
 };
 
-export const workDetail = (item) => {
+export const workDetail = (work) => {
   return {
     type: Actions.FETCH_WORK,
-    item,
+    work,
   };
 };
 
@@ -30,7 +30,6 @@ const searchUrl = apiUrl + searchPath;
 const recordUrl = apiUrl + recordPath;
 
 export const searchPost = (query, field) => {
-  // Need a parsed query input to use for each filter
   const userQuery = query || '*';
   const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
   const queryBody = buildQueryBody({ query: { field: selectedField, userQuery } });
@@ -84,7 +83,7 @@ export const serverPost = (query, field) => {
 export const serverFetchWork = (workId) => {
   return axios.get(recordUrl, { params: { recordID: workId } })
     .then((resp) => {
-      serverState.workDetail = { item: resp.data };
+      serverState.workDetail = { work: resp.data };
       return serverState;
     })
     .catch((error) => {

--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import appConfig from '../../../appConfig';
 import searchFields from '../constants/fields';
 import serverState from '../stores/InitialState';
+import { buildQueryBody } from '../search/query';
 
 export const Actions = {
   SEARCH: 'SEARCH',
@@ -30,11 +31,12 @@ const recordUrl = apiUrl + recordPath;
 
 export const searchPost = (query, field) => {
   // Need a parsed query input to use for each filter
-  const userQuery = (query) ? encodeURIComponent(query) : '*';
+  const userQuery = query || '*';
   const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
+  const queryBody = buildQueryBody({ query_string: { field: selectedField, userQuery } });
 
   return (dispatch) => {
-    return axios.post(searchUrl, { queries: [{ field: selectedField, value: userQuery }] })
+    return axios.post(searchUrl, queryBody)
       .then((resp) => {
         if (resp.data) {
           dispatch(searchResults(resp.data));
@@ -64,10 +66,11 @@ export const fetchWork = (workId) => {
 
 export const serverPost = (query, field) => {
   // Need a parsed query input to use for each filter
-  const userQuery = (query) ? encodeURIComponent(query) : '*';
+  const userQuery = query || '*';
   const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
+  const queryBody = buildQueryBody({ query_string: { field: selectedField, userQuery } });
 
-  return axios.post(searchUrl, { queries: [{ field: selectedField, value: userQuery }] })
+  return axios.post(searchUrl, queryBody)
     .then((resp) => {
       serverState.searchResults = { data: resp.data };
       return serverState;

--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -33,7 +33,7 @@ export const searchPost = (query, field) => {
   // Need a parsed query input to use for each filter
   const userQuery = query || '*';
   const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
-  const queryBody = buildQueryBody({ query_string: { field: selectedField, userQuery } });
+  const queryBody = buildQueryBody({ query: { field: selectedField, userQuery } });
 
   return (dispatch) => {
     return axios.post(searchUrl, queryBody)
@@ -68,7 +68,7 @@ export const serverPost = (query, field) => {
   // Need a parsed query input to use for each filter
   const userQuery = query || '*';
   const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
-  const queryBody = buildQueryBody({ query_string: { field: selectedField, userQuery } });
+  const queryBody = buildQueryBody({ query: { field: selectedField, userQuery } });
 
   return axios.post(searchUrl, queryBody)
     .then((resp) => {

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -42,7 +42,7 @@ class SearchForm extends React.Component {
 
     this.props.searchPost(terms, this.state.searchField)
       .then(() => {
-        this.context.router.push(`/search?q=${terms}`);
+        this.context.router.push(`/search?q=${terms}&field=${this.state.searchField}`);
       });
   }
 

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -10,20 +10,20 @@ class WorkDetail extends React.Component {
   /**
    * Convert JSON object to array for parsing detail elements into
    * a definition list for display.
-   * @param {object} detailObject
+   * @param {object} work
    * @return {string|null}
    */
-  itemDetailsObject(detailObject) {
-    return Object.keys(detailObject.item).map(key => (
-      [key, detailObject.item[key]]
+  workDetailsObject(work) {
+    return Object.keys(work).map(key => (
+      [key, work[key]]
     ));
   };
 
   render() {
-    if (!this.props.detail && _isEmpty(this.props.detail)) {
-      throw new Error('Detail element in props is missing or empty');
+    if (!this.props.work && _isEmpty(this.props.work)) {
+      throw new Error('Work prop is missing or empty');
     }
-    const { detail } = this.props;
+    const { work } = this.props;
 
     return (
       <main id="mainContent">
@@ -36,7 +36,7 @@ class WorkDetail extends React.Component {
               <h2>Work Detail</h2>
               <div id="nypl-item-details">
                 <DefinitionList
-                  data={this.itemDetailsObject(detail)}
+                  data={this.workDetailsObject(work)}
                   eReaderUrl={this.props.eReaderUrl}
                 />
               </div>
@@ -49,16 +49,18 @@ class WorkDetail extends React.Component {
 }
 
 WorkDetail.propTypes = {
+  work: PropTypes.object,
   eReaderUrl: PropTypes.string,
 };
 
 WorkDetail.defaultProps = {
+  work: {},
   eReaderUrl: '',
 };
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    detail: state.workDetail,
+    work: state.workDetail && state.workDetail.work,
   };
 };
 

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -22,12 +22,17 @@ const addFieldQuery = (queryString, field = 'keyword') => {
   }
   let fieldQuery = [];
   // Strip punctuation and process spaces as plus signs for final split.
-  const queryArr = queryString.replace(/[.,\/#!$%\^&;:{}=\-_`~()]/g, '').trim().replace(/\s+/g, '+').split('+');
+  const queryArr = queryString.replace(/[.\/#!$%\^&;{}=\-_`~()]/g, '').trim().replace(/\s+/g, '+').split('+');
+  /**
+   * Reformat the string.
+   * For multiple strings in a query, add the plus operator to AND terms together;
+   * otherwise, return a single string.
+   */
+  const esQuery = (queryArr.length > 1) ? queryArr.join(' +') : queryArr.join('');
 
-  // For each string in queryArr, add a field query object.
-  queryArr.map(query => (
-    fieldQuery.push({ field, value: encodeURIComponent(query) })
-  ));
+  // TODO: add an additional check on empty queries after the terms are processed.
+
+  fieldQuery.push({ field, value: encodeURIComponent(esQuery) });
 
   return fieldQuery;
 };

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -1,3 +1,4 @@
+
 export const getRequestParams = (query = {}) => {
   const { q = '*' } = query;
   const { field = 'keyword' } = query;
@@ -6,4 +7,68 @@ export const getRequestParams = (query = {}) => {
   return { q, field, workId };
 };
 
-export default getRequestParams;
+/**
+ * Format a single field query or field queries based on string sent. Strings
+ * are broken up by word to AND them together by adding a separate field/value
+ * object for each word given.
+ *
+ * @param {string} queryString
+ * @param {string} field
+ *
+ * @returns {string}
+ */
+const addFieldQuery = (queryString, field = 'keyword') => {
+  let fieldQuery = [];
+  // Strip punctuation and process spaces as plus signs for final split.
+  const queryArr = queryString.replace(/[.,\/#!$%\^&;:{}=\-_`~()]/g, '').trim().replace(/\s+/g, '+').split('+');
+
+  // For each string in queryArr, add a field query object.
+  queryArr.map(query => (
+    fieldQuery.push({ field, value: encodeURIComponent(query) })
+  ));
+
+  return fieldQuery;
+};
+
+/**
+ * Uses a special format as provided by the ResearchNow Search API.
+ * Default format:
+ * {
+ *   queries:
+ *   [{
+ *        field: 'keyword',
+ *        value: 'branch'
+ *   }],
+ *   filters:
+ *   [{
+ *        field: 'language',
+ *        value: 'fr'
+ *   }],
+ *   sort:
+ *   [{
+ *        field: 'title.keyword',
+ *        dir: 'asc'
+ *   }],
+ *   aggregations:
+ *   [{
+ *        type: 'terms',
+ *        field: 'title.keyword'
+ *   }],
+ *   per_page: 10,
+ *   page: 0
+ * }
+ */
+export const buildQueryBody = (queryObj = {}) => {
+  let queryBody = {};
+  if (queryObj.query_string) {
+    const { userQuery, field } = queryObj.query_string;
+    queryBody.queries = addFieldQuery(userQuery, field);
+  }
+
+  return queryBody;
+};
+
+export default {
+  getRequestParams,
+  buildQueryBody,
+};

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -1,4 +1,3 @@
-
 export const getRequestParams = (query = {}) => {
   const { q = '*' } = query;
   const { field = 'keyword' } = query;
@@ -18,6 +17,9 @@ export const getRequestParams = (query = {}) => {
  * @returns {string}
  */
 const addFieldQuery = (queryString, field = 'keyword') => {
+  if (!queryString) {
+    throw new Error('A valid query string must be passed');
+  }
   let fieldQuery = [];
   // Strip punctuation and process spaces as plus signs for final split.
   const queryArr = queryString.replace(/[.,\/#!$%\^&;:{}=\-_`~()]/g, '').trim().replace(/\s+/g, '+').split('+');
@@ -32,7 +34,7 @@ const addFieldQuery = (queryString, field = 'keyword') => {
 
 /**
  * Uses a special format as provided by the ResearchNow Search API.
- * Default format:
+ * Format with possible values:
  * {
  *   queries:
  *   [{
@@ -60,8 +62,8 @@ const addFieldQuery = (queryString, field = 'keyword') => {
  */
 export const buildQueryBody = (queryObj = {}) => {
   let queryBody = {};
-  if (queryObj.query_string) {
-    const { userQuery, field } = queryObj.query_string;
+  if (queryObj.query) {
+    const { userQuery, field } = queryObj.query;
     queryBody.queries = addFieldQuery(userQuery, field);
   }
 

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -16,7 +16,7 @@ export const workDetail = (state = null, action) => {
   switch (action.type) {
     case Actions.FETCH_WORK:
       return {
-        item: action.item,
+        work: action.work,
       };
     default:
       return state;

--- a/test/fixtures/work-detail.json
+++ b/test/fixtures/work-detail.json
@@ -1,6 +1,6 @@
 {
   "detail": {
-    "item":
+    "work":
     {
       "title": "The Tragedie of Hamlet, Prince of Denmark\nA Study with the Text of the Folio of 1623",
       "uuid": "4ce7db74-1e22-4401-b32e-4c25588981a3",

--- a/test/unit/DefinitionList.test.js
+++ b/test/unit/DefinitionList.test.js
@@ -8,8 +8,8 @@ import { detail } from '../fixtures/work-detail.json';
 
 describe('DefinitionList', () => {
   let component;
-  const detailArray = Object.keys(detail.item).map(key => (
-    [key, detail.item[key]]
+  const detailArray = Object.keys(detail.work).map(key => (
+    [key, detail.work[key]]
   ));
 
   before(() => {
@@ -49,7 +49,7 @@ describe('DefinitionList', () => {
 
   describe('EBookList', () => {
     before(() => {
-      const ebooks = detail.item.instances[0].items;
+      const ebooks = detail.work.instances[0].items;
       component = shallow(<EBookList ebooks={ebooks} />);
     });
     it('should have a list of two links', () => {

--- a/test/unit/Query.test.js
+++ b/test/unit/Query.test.js
@@ -1,0 +1,38 @@
+/* eslint-env mocha */
+import { expect } from 'chai';
+import { buildQueryBody } from '../../src/app/search/query';
+
+describe('Query Body Building', () => {
+  const query = { query: { userQuery: "$shakespeare's, ghost; select *", field: 'title' } };
+
+  it('should not contain certain punctuation', () => {
+    const queryBody = buildQueryBody(query);
+    const parsedValueOne = queryBody.queries[0].value;
+    const parsedValueTwo = queryBody.queries[1].value;
+    const parsedValueFour = queryBody.queries[3].value;
+    expect(parsedValueOne.indexOf('$')).to.equal(-1);
+    expect(parsedValueOne.indexOf(',')).to.equal(-1);
+    expect(parsedValueOne.indexOf('\'')).to.not.equal(-1);
+    expect(parsedValueTwo.indexOf(';')).to.equal(-1);
+    expect(parsedValueFour).to.equal('*');
+  });
+
+  it('should return field query objects for each word within the "queries" array.', () => {
+    const queryBody = buildQueryBody(query);
+    expect(queryBody.queries.length).to.equal(4);
+  });
+
+  it('should throw an error if an empty query string is passed', () => {
+    const emptyQuery = { query: {} };
+    expect(buildQueryBody.bind(buildQueryBody, emptyQuery)).to.throw('A valid query string must be passed');
+  });
+
+  it('should return default field when the default query string is given', () => {
+    const emptyQuery = { query: { userQuery: '*' } };
+    const defaultQueryBody = buildQueryBody(emptyQuery);
+
+    expect(defaultQueryBody).to.not.equal({});
+    expect(defaultQueryBody.queries[0].value).to.equal('*');
+    expect(defaultQueryBody.queries[0].field).to.equal('keyword');
+  });
+});

--- a/test/unit/Query.test.js
+++ b/test/unit/Query.test.js
@@ -3,28 +3,40 @@ import { expect } from 'chai';
 import { buildQueryBody } from '../../src/app/search/query';
 
 describe('Query Body Building', () => {
-  const query = { query: { userQuery: "$shakespeare's, ghost; select *", field: 'title' } };
+  let query;
+
+  beforeEach(() => {
+    query = { query: { userQuery: "$shakespeare's, ghost; select *", field: 'title' } };
+  });
 
   it('should not contain certain punctuation', () => {
     const queryBody = buildQueryBody(query);
-    const parsedValueOne = queryBody.queries[0].value;
-    const parsedValueTwo = queryBody.queries[1].value;
-    const parsedValueFour = queryBody.queries[3].value;
+    const parsedValueOne = decodeURIComponent(queryBody.queries[0].value);
     expect(parsedValueOne.indexOf('$')).to.equal(-1);
-    expect(parsedValueOne.indexOf(',')).to.equal(-1);
+    expect(parsedValueOne.indexOf('%')).to.equal(-1);
     expect(parsedValueOne.indexOf('\'')).to.not.equal(-1);
-    expect(parsedValueTwo.indexOf(';')).to.equal(-1);
-    expect(parsedValueFour).to.equal('*');
-  });
-
-  it('should return field query objects for each word within the "queries" array.', () => {
-    const queryBody = buildQueryBody(query);
-    expect(queryBody.queries.length).to.equal(4);
+    expect(parsedValueOne.indexOf(';')).to.equal(-1);
+    expect(parsedValueOne.indexOf('*')).to.not.equal(-1);
   });
 
   it('should throw an error if an empty query string is passed', () => {
     const emptyQuery = { query: {} };
     expect(buildQueryBody.bind(buildQueryBody, emptyQuery)).to.throw('A valid query string must be passed');
+  });
+
+  it('should return field query object with a single string value.', () => {
+    query = { query: { userQuery: 'shakespeare', field: 'title' } };
+    const queryBody = buildQueryBody(query);
+    expect(queryBody.queries.length).to.equal(1);
+    const queryString = decodeURIComponent(queryBody.queries[0].value);
+    expect(queryString).to.not.include(' +');
+  });
+
+  it('should return field query with multiple words joined by a plus sign.', () => {
+    const queryBody = buildQueryBody(query);
+    expect(queryBody.queries.length).to.equal(1);
+    const decodedQuery = decodeURIComponent(queryBody.queries[0].value);
+    expect(decodedQuery).to.equal("shakespeare's, +ghost +select +*");
   });
 
   it('should return default field when the default query string is given', () => {

--- a/test/unit/ResultsMetadata.test.js
+++ b/test/unit/ResultsMetadata.test.js
@@ -31,7 +31,7 @@ describe('Results Metadata', () => {
       component = shallow(<ResultsMetadata metadata={metadata} />);
     });
 
-    it('should have a message stating no results found.', () => {
+    it('should have a message displaying all 5 results found.', () => {
       expect(component.find('div')).to.have.length(1);
       expect(component.find('div').text()).to.equal('Displaying 1 - 5 of 5 ; Relevancy score: 1.332332');
     });
@@ -46,7 +46,7 @@ describe('Results Metadata', () => {
       component = shallow(<ResultsMetadata metadata={metadata} />);
     });
 
-    it('should have a message stating no results found.', () => {
+    it('should have a message displaying 10 of 15 results found.', () => {
       expect(component.find('div')).to.have.length(1);
       expect(component.find('div').text()).to.equal('Displaying 1 - 10 of 15 ; Relevancy score: 1.332332');
     });

--- a/test/unit/SearchActions.test.js
+++ b/test/unit/SearchActions.test.js
@@ -1,25 +1,43 @@
 /* eslint-env mocha */
 import { expect } from 'chai';
-import { searchResults } from '../../src/app/actions/SearchActions';
+import { searchResults, workDetail } from '../../src/app/actions/SearchActions';
 
 describe('SearchActions', () => {
   let results;
   let resultsAction;
-
-  before(() => {
-    results = {
-      id: 0,
-      _source: {
-        title: 'Sir Isaac Newton',
-      },
-    };
-    resultsAction = searchResults(results);
-  });
+  let details;
+  let workDetailAction;
 
   describe('searchResults Action', () => {
     it('should return an object with type and results', () => {
+      results = {
+        id: 0,
+        _source: {
+          title: 'Sir Isaac Newton',
+        },
+      };
+      resultsAction = searchResults(results);
+
       expect(resultsAction.type).to.equal('SEARCH');
       expect(JSON.stringify(resultsAction.results)).to.equal(JSON.stringify(results));
+    });
+  });
+
+  describe('workDetail Action', () => {
+    it('should return an object with type and workDetail', () => {
+      details = {
+        detail: {
+          item:
+          {
+            title: 'The Tragedie of Hamlet, Prince of Denmark\nA Study with the Text of the Folio of 1623',
+            rights_stmt: 'Public domain in the USA.',
+          },
+        },
+      };
+      workDetailAction = workDetail(details);
+
+      expect(workDetailAction.type).to.equal('FETCH_WORK');
+      expect(JSON.stringify(workDetailAction.item)).to.equal(JSON.stringify(details));
     });
   });
 });

--- a/test/unit/SearchActions.test.js
+++ b/test/unit/SearchActions.test.js
@@ -26,18 +26,15 @@ describe('SearchActions', () => {
   describe('workDetail Action', () => {
     it('should return an object with type and workDetail', () => {
       details = {
-        detail: {
-          item:
-          {
-            title: 'The Tragedie of Hamlet, Prince of Denmark\nA Study with the Text of the Folio of 1623',
-            rights_stmt: 'Public domain in the USA.',
-          },
+        work: {
+          title: 'The Tragedie of Hamlet, Prince of Denmark\nA Study with the Text of the Folio of 1623',
+          rights_stmt: 'Public domain in the USA.',
         },
       };
       workDetailAction = workDetail(details);
 
       expect(workDetailAction.type).to.equal('FETCH_WORK');
-      expect(JSON.stringify(workDetailAction.item)).to.equal(JSON.stringify(details));
+      expect(JSON.stringify(workDetailAction.work)).to.equal(JSON.stringify(details));
     });
   });
 });


### PR DESCRIPTION
Adds `field` to the location when searching via the client. The server should also respond to the `field` query parameter. Query objects are now built using a utility function which I'm hoping I can expand to adding filter, aggregations, sort, page and per_page elements. Some tests have been added just for testing the field queries built to send along to ES.

In the query builder, phrases are split into words, encoding moved here, and each word is added as separate field queries in an array which acts as an AND for all words so each must be present in the field. The query builder removes some punctuation including commas to split words properly which helps for author searches. This PR should satisfy all basic field level querying which need to have terms AND'd together.