### PR TITLE
Add subject search

### DIFF
--- a/appConfig.js
+++ b/appConfig.js
@@ -5,19 +5,13 @@ export default {
   port: 3001,
   webpackDevServerPort: 3000,
   baseUrl: '',
-  esUrl: {
-    development: 'http://sfr-search-api-dev.us-east-1.elasticbeanstalk.com/api/v0.1/sfr',
-    production: '',
-    basePath: '/works',
-    detailPath: '/work',
-  },
   ereader: {
     development: 'http://epub-reader-env.dvgytju99m.us-east-1.elasticbeanstalk.com/reader',
-    production: '',
+    production: 'http://epub-reader-env.dvgytju99m.us-east-1.elasticbeanstalk.com/reader',
   },
   api: {
     development: 'https://dev-platform.nypl.org/api/v0.1/research-now',
-    production: '',
+    production: 'https://dev-platform.nypl.org/api/v0.1/research-now',
     searchPath: '/search-api',
     recordPath: '/work',
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "babel-register": "6.26.0",
+    "change-case": "3.1.0",
     "clean-webpack-plugin": "0.1.17",
     "colors": "1.1.2",
     "compression": "1.7.1",

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -63,17 +63,10 @@ class SearchForm extends React.Component {
                       onChange={this.onFieldChange}
                       value={this.state.searchField}
                     >
-<<<<<<< HEAD
                       {this.props.allowedFields.map((field, key) => {
                         return (
                           <option value={field} key={key.toString()}>
                             {titleCase(field)}
-=======
-                      {this.props.allowedFields.map((element, key) => {
-                        return (
-                          <option value={element} key={key.toString()}>
-                            {titleCase(element)}
->>>>>>> bc08aa6e8290752d4ad3e41e002d1dca9a7f0847
                           </option>
                         );
                       })}
@@ -89,11 +82,7 @@ class SearchForm extends React.Component {
                       type="text"
                       aria-labelledby="search-input-field"
                       value={this.state.searchQuery}
-<<<<<<< HEAD
                       placeholder="Keyword, title, author, or subject"
-=======
-                      placeholder="Keyword, title, author or subject"
->>>>>>> bc08aa6e8290752d4ad3e41e002d1dca9a7f0847
                       onChange={this.onQueryChange}
                     />
                   </span>

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -43,7 +43,8 @@ class SearchForm extends React.Component {
 
     this.props.searchPost(terms, this.state.searchField)
       .then(() => {
-        this.context.router.push(`/search?q=${terms}&field=${this.state.searchField}`);
+        const encodedUserInput = encodeURIComponent(terms);
+        this.context.router.push(`/search?q=${encodedUserInput}&field=${this.state.searchField}`);
       });
   }
 
@@ -62,10 +63,10 @@ class SearchForm extends React.Component {
                       onChange={this.onFieldChange}
                       value={this.state.searchField}
                     >
-                      {this.props.allowedFields.map((element, key) => {
+                      {this.props.allowedFields.map((field, key) => {
                         return (
-                          <option value={element} key={key.toString()}>
-                            {titleCase(element)}
+                          <option value={field} key={key.toString()}>
+                            {titleCase(field)}
                           </option>
                         );
                       })}
@@ -81,7 +82,7 @@ class SearchForm extends React.Component {
                       type="text"
                       aria-labelledby="search-input-field"
                       value={this.state.searchQuery}
-                      placeholder="Keyword, title, author or subject"
+                      placeholder="Keyword, title, author, or subject"
                       onChange={this.onQueryChange}
                     />
                   </span>

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { titleCase } from 'change-case';
 import SearchButton from '../Button/SearchButton';
 
 class SearchForm extends React.Component {
@@ -61,15 +62,13 @@ class SearchForm extends React.Component {
                       onChange={this.onFieldChange}
                       value={this.state.searchField}
                     >
-                      <option value={this.props.allowedFields.kw} defaultValue>
-                        Keyword
-                      </option>
-                      <option value={this.props.allowedFields.ti}>
-                        Title
-                      </option>
-                      <option value={this.props.allowedFields.au}>
-                        Author
-                      </option>
+                      {this.props.allowedFields.map((element, key) => {
+                        return (
+                          <option value={element} key={key.toString()}>
+                            {titleCase(element)}
+                          </option>
+                        );
+                      })}
                     </select>
                   </span>
                 </div>
@@ -82,7 +81,7 @@ class SearchForm extends React.Component {
                       type="text"
                       aria-labelledby="search-input-field"
                       value={this.state.searchQuery}
-                      placeholder="Keyword, title, or author"
+                      placeholder="Keyword, title, author or subject"
                       onChange={this.onQueryChange}
                     />
                   </span>
@@ -103,17 +102,18 @@ class SearchForm extends React.Component {
 }
 
 SearchForm.propTypes = {
-  allowedFields: PropTypes.object,
+  allowedFields: PropTypes.array,
   searchQuery: PropTypes.string,
   searchField: PropTypes.string,
 };
 
 SearchForm.defaultProps = {
-  allowedFields: {
-    kw: 'keyword',
-    ti: 'title',
-    au: 'author',
-  },
+  allowedFields: [
+    'keyword',
+    'title',
+    'author',
+    'subject',
+  ],
   searchQuery: '',
   searchField: '',
 };

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -63,10 +63,17 @@ class SearchForm extends React.Component {
                       onChange={this.onFieldChange}
                       value={this.state.searchField}
                     >
+<<<<<<< HEAD
                       {this.props.allowedFields.map((field, key) => {
                         return (
                           <option value={field} key={key.toString()}>
                             {titleCase(field)}
+=======
+                      {this.props.allowedFields.map((element, key) => {
+                        return (
+                          <option value={element} key={key.toString()}>
+                            {titleCase(element)}
+>>>>>>> bc08aa6e8290752d4ad3e41e002d1dca9a7f0847
                           </option>
                         );
                       })}
@@ -82,7 +89,11 @@ class SearchForm extends React.Component {
                       type="text"
                       aria-labelledby="search-input-field"
                       value={this.state.searchQuery}
+<<<<<<< HEAD
                       placeholder="Keyword, title, author, or subject"
+=======
+                      placeholder="Keyword, title, author or subject"
+>>>>>>> bc08aa6e8290752d4ad3e41e002d1dca9a7f0847
                       onChange={this.onQueryChange}
                     />
                   </span>

--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { isEmpty as _isEmpty } from 'underscore';
 import EBookList from '../List/EBookList';
+import { searchPost } from '../../actions/SearchActions';
 
 const elements = ['title', 'entities', 'instances', 'subjects', 'rights_stmt', 'language'];
 export const labels = {
@@ -17,13 +18,31 @@ export const labels = {
 /**
  * Build a definition list of elements from a bibliographic record provided
  * by Elastisearch.
+ *
  * @param {object} props
  */
 export const DefinitionList = (props) => {
   /**
+   * onClick handler for browse searches.
+   *
+   * @param {object} event
+   * @param {string} query
+   * @param {string} field
+   */
+  const newSearchRequest = (event, query, field) => {
+    event.preventDefault();
+
+    props.dispatch(searchPost(query, field))
+      .then(() => {
+        props.context.router.push(`/search?q=${query}&field=${field}`);
+      });
+  };
+
+  /**
    * Handle elements with array values as definitions. Authorities are linked to
    * /search as new general searches with URL parameters. Items are mapped to a table
    * with a row for each edition.
+   *
    * @param {string} type
    * @param {array} entries
    * @return {string|null}
@@ -35,7 +54,10 @@ export const DefinitionList = (props) => {
           <ul>
             {entries.map((entity, i) => (
               <li key={i.toString()}>
-                <Link to={{ pathname: '/search', query: { q: `${entity.name}`, field: 'author' } }}>{entity.name}, {entity.role}</Link>
+                <Link
+                  onClick={event => newSearchRequest(event, entity.name, 'author')}
+                  to={{ pathname: '/search', query: { q: `${entity.name}`, field: 'author' } }}>{entity.name}, {entity.role}
+                </Link>
               </li>
             ))}
           </ul>
@@ -46,7 +68,10 @@ export const DefinitionList = (props) => {
           <ul>
             {entries.map((subject, i) => (
               <li key={i.toString()}>
-                <Link to={{ pathname: '/search', query: { q: `${subject.subject}`, field: 'subject' } }}>{subject.subject}</Link>
+                <Link
+                  onClick={event => newSearchRequest(event, subject.subject, 'subject')}
+                  to={{ pathname: '/search', query: { q: `${subject.subject}`, field: 'subject' } }}>{subject.subject}
+                </Link>
               </li>
             ))}
           </ul>
@@ -83,6 +108,7 @@ export const DefinitionList = (props) => {
 
   /**
    * Wrapper function to handle building the HTML from the object given.
+   *
    * @param {array} data
    * @return {string}
    */

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -10,6 +10,7 @@ class WorkDetail extends React.Component {
   /**
    * Convert JSON object to array for parsing detail elements into
    * a definition list for display.
+   *
    * @param {object} work
    * @return {string|null}
    */
@@ -38,6 +39,8 @@ class WorkDetail extends React.Component {
                 <DefinitionList
                   data={this.workDetailsObject(work)}
                   eReaderUrl={this.props.eReaderUrl}
+                  dispatch={this.props.dispatch}
+                  context={this.context}
                 />
               </div>
             </div>
@@ -56,6 +59,10 @@ WorkDetail.propTypes = {
 WorkDetail.defaultProps = {
   work: {},
   eReaderUrl: '',
+};
+
+WorkDetail.contextTypes = {
+  router: PropTypes.object,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/app/constants/fields.js
+++ b/src/app/constants/fields.js
@@ -1,7 +1,7 @@
 const fields = {
   author: 'entities.name',
   title: 'title',
-  subject: 'subject',
+  subject: 'subjects.subject',
   publDate: 'publicationDate',
   publisher: 'publisher',
 };

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -21,18 +21,17 @@ const addFieldQuery = (queryString, field = 'keyword') => {
     throw new Error('A valid query string must be passed');
   }
   let fieldQuery = [];
-  // Strip punctuation and process spaces as plus signs for final split.
-  const queryArr = queryString.replace(/[.\/#!$%\^&;{}=\-_`~()]/g, '').trim().replace(/\s+/g, '+').split('+');
   /**
-   * Reformat the string.
-   * For multiple strings in a query, add the plus operator to AND terms together;
-   * otherwise, return a single string.
+   * Strip punctuation and process spaces as plus signs for final split.
+   * ES characters to escape before sending: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
+   * For multiple strings in a query, join with a space.
    */
-  const esQuery = (queryArr.length > 1) ? queryArr.join(' +') : queryArr.join('');
+  const queryArr = queryString.replace(/[=(&&)(||)><!(){}\[\]^"~\*\?:\/-]/g, '\$&').trim().replace(/\s+/g, '+').split('+');
+  const esQuery = (queryArr.length > 1) ? queryArr.join(' ') : queryArr.join('');
 
   // TODO: add an additional check on empty queries after the terms are processed.
 
-  fieldQuery.push({ field, value: encodeURIComponent(esQuery) });
+  fieldQuery.push({ field, value: esQuery });
 
   return fieldQuery;
 };
@@ -64,6 +63,9 @@ const addFieldQuery = (queryString, field = 'keyword') => {
  *   per_page: 10,
  *   page: 0
  * }
+ * 
+ * @param {object} queryObj
+ * @return {object}
  */
 export const buildQueryBody = (queryObj = {}) => {
   let queryBody = {};

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -24,14 +24,12 @@ const addFieldQuery = (queryString, field = 'keyword') => {
   /**
    * Strip punctuation and process spaces as plus signs for final split.
    * ES characters to escape before sending: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
-   * For multiple strings in a query, join with a space.
    */
   const queryArr = queryString.replace(/[=(&&)(||)><!(){}\[\]^"~\*\?:\/-]/g, '\$&').trim().replace(/\s+/g, '+').split('+');
-  const esQuery = (queryArr.length > 1) ? queryArr.join(' ') : queryArr.join('');
 
   // TODO: add an additional check on empty queries after the terms are processed.
 
-  fieldQuery.push({ field, value: esQuery });
+  fieldQuery.push({ field, value: queryArr.join(' ') });
 
   return fieldQuery;
 };

--- a/src/client/styles/components/Search.scss
+++ b/src/client/styles/components/Search.scss
@@ -84,7 +84,15 @@
     .nypl-omnisearch-button {
       border: solid 0.0625rem #080807;
       border-radius: 0.2rem;
-      width: 6rem;
+      width: 100%;
+      min-width: 100%;
+      max-width: 100%;
+      padding-left: 10px;
+    }
+
+    svg {
+      margin-left: 58%;
+      margin-right: 55%;
     }
 
     .nypl-text-field {

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -20,7 +20,7 @@ $nypl-dark-blue: #135772;
 
 #mainContent {
   margin: 0 auto;
-  width: 1024px;
+  width: 100%;
   min-height: 400px;
 }
 

--- a/test/unit/Query.test.js
+++ b/test/unit/Query.test.js
@@ -6,17 +6,16 @@ describe('Query Body Building', () => {
   let query;
 
   beforeEach(() => {
-    query = { query: { userQuery: "$shakespeare's, ghost; select *", field: 'title' } };
+    query = { query: { userQuery: "$shakespeare's, 1632-1635 +hamlet gh:ost; select * && delete * || drop *", field: 'title' } };
   });
 
   it('should not contain certain punctuation', () => {
     const queryBody = buildQueryBody(query);
-    const parsedValueOne = decodeURIComponent(queryBody.queries[0].value);
-    expect(parsedValueOne.indexOf('$')).to.equal(-1);
-    expect(parsedValueOne.indexOf('%')).to.equal(-1);
+    const parsedValueOne = queryBody.queries[0].value;
+    expect(parsedValueOne.indexOf('\\$')).to.equal(-1);
     expect(parsedValueOne.indexOf('\'')).to.not.equal(-1);
-    expect(parsedValueOne.indexOf(';')).to.equal(-1);
-    expect(parsedValueOne.indexOf('*')).to.not.equal(-1);
+    expect(parsedValueOne.indexOf('\\;')).to.equal(-1);
+    expect(parsedValueOne.indexOf('\*')).to.not.equal(-1);
   });
 
   it('should throw an error if an empty query string is passed', () => {
@@ -28,15 +27,15 @@ describe('Query Body Building', () => {
     query = { query: { userQuery: 'shakespeare', field: 'title' } };
     const queryBody = buildQueryBody(query);
     expect(queryBody.queries.length).to.equal(1);
-    const queryString = decodeURIComponent(queryBody.queries[0].value);
-    expect(queryString).to.not.include(' +');
+    const queryString = queryBody.queries[0].value;
+    expect(queryString).to.not.include(' ');
   });
 
   it('should return field query with multiple words joined by a plus sign.', () => {
     const queryBody = buildQueryBody(query);
     expect(queryBody.queries.length).to.equal(1);
-    const decodedQuery = decodeURIComponent(queryBody.queries[0].value);
-    expect(decodedQuery).to.equal("shakespeare's, +ghost +select +*");
+    const decodedQuery = queryBody.queries[0].value;
+    expect(decodedQuery).to.equal("$shakespeare's, 1632\-1635  hamlet gh\:ost; select \* \&\& delete \* \|\| drop \*");
   });
 
   it('should return default field when the default query string is given', () => {
@@ -44,7 +43,7 @@ describe('Query Body Building', () => {
     const defaultQueryBody = buildQueryBody(emptyQuery);
 
     expect(defaultQueryBody).to.not.equal({});
-    expect(defaultQueryBody.queries[0].value).to.equal('*');
+    expect(defaultQueryBody.queries[0].value).to.equal('\*');
     expect(defaultQueryBody.queries[0].field).to.equal('keyword');
   });
 });

--- a/test/unit/SearchForm.test.js
+++ b/test/unit/SearchForm.test.js
@@ -18,7 +18,7 @@ describe('SearchForm', () => {
 
     it('contains a select with three options.', () => {
       const options = component.find('option');
-      expect(options).to.have.length(3);
+      expect(options).to.have.length(4);
     });
 
     it('contains an option for keyword.', () => {
@@ -36,10 +36,15 @@ describe('SearchForm', () => {
       expect(authorOpt.nodes[2].value).to.equal('author');
     });
 
+    it('contains an option for subject.', () => {
+      const authorOpt = component.find('option');
+      expect(authorOpt.nodes[3].value).to.equal('subject');
+    });
+
     it('contains a text field for keyword search with an initial value.', () => {
       const kwTextField = component.find('input');
       expect(kwTextField.nodes[0].type).to.equal('text');
-      expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, or author');
+      expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author or subject');
     });
   });
 

--- a/test/unit/SearchForm.test.js
+++ b/test/unit/SearchForm.test.js
@@ -44,11 +44,7 @@ describe('SearchForm', () => {
     it('contains a text field for keyword search with an initial value.', () => {
       const kwTextField = component.find('input');
       expect(kwTextField.nodes[0].type).to.equal('text');
-<<<<<<< HEAD
       expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author, or subject');
-=======
-      expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author or subject');
->>>>>>> bc08aa6e8290752d4ad3e41e002d1dca9a7f0847
     });
   });
 

--- a/test/unit/SearchForm.test.js
+++ b/test/unit/SearchForm.test.js
@@ -44,7 +44,7 @@ describe('SearchForm', () => {
     it('contains a text field for keyword search with an initial value.', () => {
       const kwTextField = component.find('input');
       expect(kwTextField.nodes[0].type).to.equal('text');
-      expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author or subject');
+      expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author, or subject');
     });
   });
 

--- a/test/unit/SearchForm.test.js
+++ b/test/unit/SearchForm.test.js
@@ -44,7 +44,11 @@ describe('SearchForm', () => {
     it('contains a text field for keyword search with an initial value.', () => {
       const kwTextField = component.find('input');
       expect(kwTextField.nodes[0].type).to.equal('text');
+<<<<<<< HEAD
       expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author, or subject');
+=======
+      expect(kwTextField.nodes[0].placeholder).to.equal('Keyword, title, author or subject');
+>>>>>>> bc08aa6e8290752d4ad3e41e002d1dca9a7f0847
     });
   });
 


### PR DESCRIPTION
* adds subject search option to form
* consolidates option value rendering on SearchForm 
* adds the change-case npm package for capitalizing labels for search form options and other potential uses in the project. If there's a better one, just let me know.
* adds onClick handler for author and subject links on detail pages to the DefinitionList component
** passed dispatch and context from WorkDetail component for onClick handler