### PR TITLE
Small fix to query parsing

### DIFF
--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -26,7 +26,7 @@ const addFieldQuery = (queryString, field = 'keyword') => {
    * ES characters to escape before sending: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
    * For multiple strings in a query, join with a space.
    */
-  const queryArr = queryString.replace(/[=(&&)(||)><!(){}\[\]^"~\*\?:\/-]/g, '\\$&').trim().replace(/\s+/g, '+').split('+');
+  const queryArr = queryString.replace(/[=(&&)(||)><!(){}\[\]^"~\*\?:\/-]/g, '\$&').trim().replace(/\s+/g, '+').split('+');
   const esQuery = (queryArr.length > 1) ? queryArr.join(' ') : queryArr.join('');
 
   // TODO: add an additional check on empty queries after the terms are processed.

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -21,18 +21,17 @@ const addFieldQuery = (queryString, field = 'keyword') => {
     throw new Error('A valid query string must be passed');
   }
   let fieldQuery = [];
-  // Strip punctuation and process spaces as plus signs for final split.
-  const queryArr = queryString.replace(/[.\/#!$%\^&;{}=\-_`~()]/g, '').trim().replace(/\s+/g, '+').split('+');
   /**
-   * Reformat the string.
-   * For multiple strings in a query, add the plus operator to AND terms together;
-   * otherwise, return a single string.
+   * Strip punctuation and process spaces as plus signs for final split.
+   * ES characters to escape before sending: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
+   * For multiple strings in a query, join with a space.
    */
-  const esQuery = (queryArr.length > 1) ? queryArr.join(' +') : queryArr.join('');
+  const queryArr = queryString.replace(/[=(&&)(||)><!(){}\[\]^"~\*\?:\/-]/g, '\\$&').trim().replace(/\s+/g, '+').split('+');
+  const esQuery = (queryArr.length > 1) ? queryArr.join(' ') : queryArr.join('');
 
   // TODO: add an additional check on empty queries after the terms are processed.
 
-  fieldQuery.push({ field, value: encodeURIComponent(esQuery) });
+  fieldQuery.push({ field, value: esQuery });
 
   return fieldQuery;
 };
@@ -64,6 +63,9 @@ const addFieldQuery = (queryString, field = 'keyword') => {
  *   per_page: 10,
  *   page: 0
  * }
+ * 
+ * @param {object} queryObj
+ * @return {object}
  */
 export const buildQueryBody = (queryObj = {}) => {
   let queryBody = {};

--- a/test/unit/Query.test.js
+++ b/test/unit/Query.test.js
@@ -15,7 +15,7 @@ describe('Query Body Building', () => {
     expect(parsedValueOne.indexOf('\\$')).to.equal(-1);
     expect(parsedValueOne.indexOf('\'')).to.not.equal(-1);
     expect(parsedValueOne.indexOf('\\;')).to.equal(-1);
-    expect(parsedValueOne.indexOf('\\*')).to.not.equal(-1);
+    expect(parsedValueOne.indexOf('\*')).to.not.equal(-1);
   });
 
   it('should throw an error if an empty query string is passed', () => {
@@ -35,7 +35,7 @@ describe('Query Body Building', () => {
     const queryBody = buildQueryBody(query);
     expect(queryBody.queries.length).to.equal(1);
     const decodedQuery = queryBody.queries[0].value;
-    expect(decodedQuery).to.equal("$shakespeare's, 1632\\-1635  hamlet gh\\:ost; select \\* \\&\\& delete \\* \\|\\| drop \\*");
+    expect(decodedQuery).to.equal("$shakespeare's, 1632\-1635  hamlet gh\:ost; select \* \&\& delete \* \|\| drop \*");
   });
 
   it('should return default field when the default query string is given', () => {
@@ -43,7 +43,7 @@ describe('Query Body Building', () => {
     const defaultQueryBody = buildQueryBody(emptyQuery);
 
     expect(defaultQueryBody).to.not.equal({});
-    expect(defaultQueryBody.queries[0].value).to.equal('\\*');
+    expect(defaultQueryBody.queries[0].value).to.equal('\*');
     expect(defaultQueryBody.queries[0].field).to.equal('keyword');
   });
 });

--- a/test/unit/Query.test.js
+++ b/test/unit/Query.test.js
@@ -6,17 +6,16 @@ describe('Query Body Building', () => {
   let query;
 
   beforeEach(() => {
-    query = { query: { userQuery: "$shakespeare's, ghost; select *", field: 'title' } };
+    query = { query: { userQuery: "$shakespeare's, 1632-1635 +hamlet gh:ost; select * && delete * || drop *", field: 'title' } };
   });
 
   it('should not contain certain punctuation', () => {
     const queryBody = buildQueryBody(query);
-    const parsedValueOne = decodeURIComponent(queryBody.queries[0].value);
-    expect(parsedValueOne.indexOf('$')).to.equal(-1);
-    expect(parsedValueOne.indexOf('%')).to.equal(-1);
+    const parsedValueOne = queryBody.queries[0].value;
+    expect(parsedValueOne.indexOf('\\$')).to.equal(-1);
     expect(parsedValueOne.indexOf('\'')).to.not.equal(-1);
-    expect(parsedValueOne.indexOf(';')).to.equal(-1);
-    expect(parsedValueOne.indexOf('*')).to.not.equal(-1);
+    expect(parsedValueOne.indexOf('\\;')).to.equal(-1);
+    expect(parsedValueOne.indexOf('\\*')).to.not.equal(-1);
   });
 
   it('should throw an error if an empty query string is passed', () => {
@@ -28,15 +27,15 @@ describe('Query Body Building', () => {
     query = { query: { userQuery: 'shakespeare', field: 'title' } };
     const queryBody = buildQueryBody(query);
     expect(queryBody.queries.length).to.equal(1);
-    const queryString = decodeURIComponent(queryBody.queries[0].value);
-    expect(queryString).to.not.include(' +');
+    const queryString = queryBody.queries[0].value;
+    expect(queryString).to.not.include(' ');
   });
 
   it('should return field query with multiple words joined by a plus sign.', () => {
     const queryBody = buildQueryBody(query);
     expect(queryBody.queries.length).to.equal(1);
-    const decodedQuery = decodeURIComponent(queryBody.queries[0].value);
-    expect(decodedQuery).to.equal("shakespeare's, +ghost +select +*");
+    const decodedQuery = queryBody.queries[0].value;
+    expect(decodedQuery).to.equal("$shakespeare's, 1632\\-1635  hamlet gh\\:ost; select \\* \\&\\& delete \\* \\|\\| drop \\*");
   });
 
   it('should return default field when the default query string is given', () => {
@@ -44,7 +43,7 @@ describe('Query Body Building', () => {
     const defaultQueryBody = buildQueryBody(emptyQuery);
 
     expect(defaultQueryBody).to.not.equal({});
-    expect(defaultQueryBody.queries[0].value).to.equal('*');
+    expect(defaultQueryBody.queries[0].value).to.equal('\\*');
     expect(defaultQueryBody.queries[0].field).to.equal('keyword');
   });
 });


### PR DESCRIPTION
Fixes issues with sending the a user input query properly to the search API. Uses an escape character strategy rather than removing ES escape characters.