### PR TITLE
Add phrase searching for browse links

### DIFF
--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -55,8 +55,8 @@ export const DefinitionList = (props) => {
             {entries.map((entity, i) => (
               <li key={i.toString()}>
                 <Link
-                  onClick={event => newSearchRequest(event, entity.name, 'author')}
-                  to={{ pathname: '/search', query: { q: `${entity.name}`, field: 'author' } }}>{entity.name}, {entity.role}
+                  onClick={event => newSearchRequest(event, `\"${entity.name}\"`, 'author')}
+                  to={{ pathname: '/search', query: { q: `\"${entity.name}\"`, field: 'author' } }}>{entity.name}, {entity.role}
                 </Link>
               </li>
             ))}
@@ -69,8 +69,8 @@ export const DefinitionList = (props) => {
             {entries.map((subject, i) => (
               <li key={i.toString()}>
                 <Link
-                  onClick={event => newSearchRequest(event, subject.subject, 'subject')}
-                  to={{ pathname: '/search', query: { q: `${subject.subject}`, field: 'subject' } }}>{subject.subject}
+                  onClick={event => newSearchRequest(event, `\"${subject.subject}\"`, 'subject')}
+                  to={{ pathname: '/search', query: { q: `\"${subject.subject}\"`, field: 'subject' } }}>{subject.subject}
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
Adds quotes around queries that "browse" the index via subjects and authors. The subject links in particular need to be quoted, or any other multi-word search terms, to ensure an exact match.

Author links may change to use their identifiers instead, but the change here to search the exact name via quotes should provide the expected result.