### PR TITLE
Add Breadcrumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "history": "3.3.0",
     "node-sass": "3.8.0",
     "prop-types": "15.6.2",
+    "query-string": "6.4.0",
     "react": "15.5.4",
     "react-a11y": "1.1.0",
     "react-dom": "15.5.4",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "history": "3.3.0",
     "node-sass": "3.8.0",
     "prop-types": "15.6.2",
-    "query-string": "6.4.0",
     "react": "15.5.4",
     "react-a11y": "1.1.0",
     "react-dom": "15.5.4",

--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -7,6 +7,22 @@ import { buildQueryBody } from '../search/query';
 export const Actions = {
   SEARCH: 'SEARCH',
   FETCH_WORK: 'FETCH_WORK',
+  SET_QUERY: 'SET_QUERY',
+  SET_FIELD: 'SET_FIELD',
+};
+
+export const userQuery = (query) => {
+  return {
+    type: Actions.SET_QUERY,
+    userQuery: query,
+  };
+};
+
+export const selectedField = (field) => {
+  return {
+    type: Actions.SET_FIELD,
+    selectedField: field,
+  };
 };
 
 export const searchResults = (results) => {
@@ -30,9 +46,9 @@ const searchUrl = apiUrl + searchPath;
 const recordUrl = apiUrl + recordPath;
 
 export const searchPost = (query, field) => {
-  const userQuery = query || '*';
-  const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
-  const queryBody = buildQueryBody({ query: { field: selectedField, userQuery } });
+  const selectQuery = query || '*';
+  const selectField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
+  const queryBody = buildQueryBody({ query: { field: selectField, selectQuery } });
 
   return (dispatch) => {
     return axios.post(searchUrl, queryBody)
@@ -65,9 +81,9 @@ export const fetchWork = (workId) => {
 
 export const serverPost = (query, field) => {
   // Need a parsed query input to use for each filter
-  const userQuery = query || '*';
-  const selectedField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
-  const queryBody = buildQueryBody({ query: { field: selectedField, userQuery } });
+  const selectQuery = query || '*';
+  const selectField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
+  const queryBody = buildQueryBody({ query: { field: selectField, selectQuery } });
 
   return axios.post(searchUrl, queryBody)
     .then((resp) => {
@@ -97,4 +113,6 @@ export default {
   fetchWork,
   serverPost,
   serverFetchWork,
+  userQuery,
+  selectedField,
 };

--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import appConfig from '../../../appConfig';
-import searchFields from '../constants/fields';
+import selectFields from '../constants/fields';
 import serverState from '../stores/InitialState';
 import { buildQueryBody } from '../search/query';
 
@@ -15,14 +15,14 @@ export const Actions = {
 export const userQuery = (query) => {
   return {
     type: Actions.SET_QUERY,
-    userQuery: query,
+    searchQuery: query,
   };
 };
 
 export const selectedField = (field) => {
   return {
     type: Actions.SET_FIELD,
-    selectedField: field,
+    searchField: field,
   };
 };
 
@@ -55,8 +55,8 @@ const recordUrl = apiUrl + recordPath;
 
 export const searchPost = (query, field) => {
   const selectQuery = query || '*';
-  const selectField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
-  const queryBody = buildQueryBody({ query: { field: selectField, selectQuery } });
+  const selectField = (field && selectFields[field]) ? selectFields[field] : 'keyword';
+  const queryBody = buildQueryBody({ query: { selectField, selectQuery } });
 
   return (dispatch) => {
     return axios.post(searchUrl, queryBody)
@@ -90,13 +90,13 @@ export const fetchWork = (workId) => {
 export const serverPost = (query, field) => {
   // Need a parsed query input to use for each filter
   const selectQuery = query || '*';
-  const selectField = (field && searchFields[field]) ? searchFields[field] : 'keyword';
-  const queryBody = buildQueryBody({ query: { field: selectField, selectQuery } });
+  const selectField = (field && selectFields[field]) ? selectFields[field] : 'keyword';
+  const queryBody = buildQueryBody({ query: { selectField, selectQuery } });
 
   return axios.post(searchUrl, queryBody)
     .then((resp) => {
-      serverState.userQuery = query;
-      serverState.selectedField = field;
+      serverState.searchQuery = query;
+      serverState.searchField = field;
       serverState.searchResults = { data: resp.data };
       return serverState;
     })

--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -87,6 +87,8 @@ export const serverPost = (query, field) => {
 
   return axios.post(searchUrl, queryBody)
     .then((resp) => {
+      serverState.userQuery = query;
+      serverState.selectedField = field;
       serverState.searchResults = { data: resp.data };
       return serverState;
     })

--- a/src/app/actions/SearchActions.js
+++ b/src/app/actions/SearchActions.js
@@ -9,6 +9,7 @@ export const Actions = {
   FETCH_WORK: 'FETCH_WORK',
   SET_QUERY: 'SET_QUERY',
   SET_FIELD: 'SET_FIELD',
+  RESET_SEARCH: 'RESET_SEARCH',
 };
 
 export const userQuery = (query) => {
@@ -36,6 +37,13 @@ export const workDetail = (work) => {
   return {
     type: Actions.FETCH_WORK,
     work,
+  };
+};
+
+export const resetSearch = () => {
+  return {
+    type: Actions.RESET_SEARCH,
+    reset: true,
   };
 };
 
@@ -117,4 +125,5 @@ export default {
   serverFetchWork,
   userQuery,
   selectedField,
+  resetSearch,
 };

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -25,17 +25,13 @@ const Breadcrumbs = (({ links, pageType, onClickHandler }) => {
   const crumbTrail = () => {
     const crumbs = [homeLink];
 
-    if (links && Array.isArray(links)) {
-      links.map((link, iterator) => {
-        if (iterator < links.length-1) {
-          crumbs.push(
-            <li key={iterator}>
-              <Link to={link.href}>
-                {link.text}
-              </Link>
-            </li>);
+    if (links && links.length) {
+      links.forEach((link, iterator) => {
+        const linkKey = `links-${iterator}`;
+        if (iterator < links.length - 1) {
+          crumbs.push(<li key={linkKey}><Link href={link.href}>{link.text}</Link></li>);
         } else {
-          crumbs.push(<li key={iterator}>{link.text}</li>);
+          crumbs.push(<li key={linkKey}>{link.text}</li>);
         }
       });
     }

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router';
  * @param {object} props
  * @returns {array}
  */
-const Breadcrumbs = (({ query = '', type, workUrl }) => {
+const Breadcrumbs = (({ query = '', field = '', type }) => {
   if (type === 'home') {
     return null;
   }
@@ -17,7 +17,7 @@ const Breadcrumbs = (({ query = '', type, workUrl }) => {
 
   const homeLink = (
     <li key="home">
-      <Link to={'/'} onClick={() => onClick('ResarchNow')}>
+      <Link to={'/'}>
         ResearchNow
       </Link>
     </li>);
@@ -32,7 +32,7 @@ const Breadcrumbs = (({ query = '', type, workUrl }) => {
 
     crumbs.push(
       <li key="results">
-        <Link to={`/search?q=${query}`} onClick={() => onClick('Search Results')}>
+        <Link to={`/search?q=${query}&field=${field}`}>
           Search Results
         </Link>
       </li>);
@@ -44,7 +44,7 @@ const Breadcrumbs = (({ query = '', type, workUrl }) => {
 
     crumbs.push(
       <li key="details">
-        <Link to={`/work`} onClick={() => onClick('Work Details')}>Work Details</Link>
+        <Link to={`/work`}>Work Details</Link>
       </li>);
 
     return crumbs;
@@ -64,6 +64,7 @@ const Breadcrumbs = (({ query = '', type, workUrl }) => {
 
 Breadcrumbs.propTypes = {
   query: PropTypes.string,
+  field: PropTypes.string,
   type: PropTypes.string,
 };
 

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -29,7 +29,7 @@ const Breadcrumbs = (({ links, pageType, onClickHandler }) => {
       links.forEach((link, iterator) => {
         const linkKey = `links-${iterator}`;
         if (iterator < links.length - 1) {
-          crumbs.push(<li key={linkKey}><Link href={link.href}>{link.text}</Link></li>);
+          crumbs.push(<li key={linkKey}><Link to={link.href}>{link.text}</Link></li>);
         } else {
           crumbs.push(<li key={linkKey}>{link.text}</li>);
         }

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -8,8 +8,8 @@ import { Link } from 'react-router';
  * @param {object} props
  * @returns {array}
  */
-const Breadcrumbs = (({ query = '', field = '', type }) => {
-  if (type === 'home') {
+const Breadcrumbs = (({ query = '', field = '', pageType, handleReset }) => {
+  if (pageType === 'home') {
     return null;
   }
 
@@ -17,7 +17,7 @@ const Breadcrumbs = (({ query = '', field = '', type }) => {
 
   const homeLink = (
     <li key="home">
-      <Link to={'/'}>
+      <Link to={'/'} onClick={event => handleReset(event)}>
         ResearchNow
       </Link>
     </li>);
@@ -25,7 +25,7 @@ const Breadcrumbs = (({ query = '', field = '', type }) => {
   const crumbTrail = () => {
     const crumbs = [homeLink];
 
-    if (type === 'results') {
+    if (pageType === 'results') {
       crumbs.push(<li key="results">Search Results</li>);
       return crumbs;
     }
@@ -37,7 +37,7 @@ const Breadcrumbs = (({ query = '', field = '', type }) => {
         </Link>
       </li>);
 
-    if (type === 'details') {
+    if (pageType === 'details') {
       crumbs.push(<li key="details">Work Detail</li>);
       return crumbs;
     }
@@ -65,7 +65,15 @@ const Breadcrumbs = (({ query = '', field = '', type }) => {
 Breadcrumbs.propTypes = {
   query: PropTypes.string,
   field: PropTypes.string,
-  type: PropTypes.string,
+  pageType: PropTypes.string,
+  handleReset: PropTypes.func,
+};
+
+Breadcrumbs.defaultTypes = {
+  query: '',
+  field: '',
+  pageType: 'home',
+  handleReset: () => {},
 };
 
 export default Breadcrumbs;

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -2,13 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-const Breadcrumbs = ((query, type) => {
-  const onClick = pageTitle => tracker('Breadcrumbs', pageTitle);
+/**
+ * Takes `query` and `type` as properties to pass to its methods.
+ *
+ * @param {object} props
+ * @returns {array}
+ */
+const Breadcrumbs = (({ query = '', type, workUrl }) => {
+  if (type === 'home') {
+    return null;
+  }
+
+  // const onClick = pageTitle => tracker('Breadcrumbs', pageTitle);
 
   const homeLink = (
     <li key="home">
-      <Link to={'/'} onClick={() => onClick('Home')}>
-        Home
+      <Link to={'/'} onClick={() => onClick('ResarchNow')}>
+        ResearchNow
       </Link>
     </li>);
 
@@ -17,21 +27,24 @@ const Breadcrumbs = ((query, type) => {
 
     if (type === 'results') {
       crumbs.push(<li key="results">Search Results</li>);
+      return crumbs;
     }
 
     crumbs.push(
       <li key="results">
-        <Link to={`/search?q=${query.q}`} onClick={() => onClick('Search Results')}>
+        <Link to={`/search?q=${query}`} onClick={() => onClick('Search Results')}>
           Search Results
         </Link>
       </li>);
 
     if (type === 'details') {
-      crumbs.push(<li key="details">Work Details</li>);
+      crumbs.push(<li key="details">Work Detail</li>);
+      return crumbs;
     }
+
     crumbs.push(
       <li key="details">
-        <Link to={`/work?workId=${query.q}`} onClick={() => onClick('Work Details')}>Work Details</Link>
+        <Link to={`/work`} onClick={() => onClick('Work Details')}>Work Details</Link>
       </li>);
 
     return crumbs;
@@ -51,11 +64,7 @@ const Breadcrumbs = ((query, type) => {
 
 Breadcrumbs.propTypes = {
   query: PropTypes.string,
-  field: PropTypes.string,
   type: PropTypes.string,
-  match: PropTypes.object,
-  location: PropTypes.object,
-  history: PropTypes.object,
 };
 
 export default Breadcrumbs;

--- a/src/app/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/app/components/Breadcrumbs/Breadcrumbs.jsx
@@ -8,7 +8,7 @@ import { Link } from 'react-router';
  * @param {object} props
  * @returns {array}
  */
-const Breadcrumbs = (({ query = '', field = '', pageType, handleReset }) => {
+const Breadcrumbs = (({ links, pageType, onClickHandler }) => {
   if (pageType === 'home') {
     return null;
   }
@@ -17,7 +17,7 @@ const Breadcrumbs = (({ query = '', field = '', pageType, handleReset }) => {
 
   const homeLink = (
     <li key="home">
-      <Link to={'/'} onClick={event => handleReset(event)}>
+      <Link to="/" onClick={event => onClickHandler(event)}>
         ResearchNow
       </Link>
     </li>);
@@ -25,27 +25,20 @@ const Breadcrumbs = (({ query = '', field = '', pageType, handleReset }) => {
   const crumbTrail = () => {
     const crumbs = [homeLink];
 
-    if (pageType === 'results') {
-      crumbs.push(<li key="results">Search Results</li>);
-      return crumbs;
+    if (links && Array.isArray(links)) {
+      links.map((link, iterator) => {
+        if (iterator < links.length-1) {
+          crumbs.push(
+            <li key={iterator}>
+              <Link to={link.href}>
+                {link.text}
+              </Link>
+            </li>);
+        } else {
+          crumbs.push(<li key={iterator}>{link.text}</li>);
+        }
+      });
     }
-
-    crumbs.push(
-      <li key="results">
-        <Link to={`/search?q=${query}&field=${field}`}>
-          Search Results
-        </Link>
-      </li>);
-
-    if (pageType === 'details') {
-      crumbs.push(<li key="details">Work Detail</li>);
-      return crumbs;
-    }
-
-    crumbs.push(
-      <li key="details">
-        <Link to={`/work`}>Work Details</Link>
-      </li>);
 
     return crumbs;
   };
@@ -63,17 +56,15 @@ const Breadcrumbs = (({ query = '', field = '', pageType, handleReset }) => {
 });
 
 Breadcrumbs.propTypes = {
-  query: PropTypes.string,
-  field: PropTypes.string,
+  links: PropTypes.array,
   pageType: PropTypes.string,
-  handleReset: PropTypes.func,
+  onClickHandler: PropTypes.func,
 };
 
-Breadcrumbs.defaultTypes = {
-  query: '',
-  field: '',
+Breadcrumbs.defaultProps = {
+  links: [],
   pageType: 'home',
-  handleReset: () => {},
+  onClickHandler: () => {},
 };
 
 export default Breadcrumbs;

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -25,10 +26,13 @@ class SearchContainer extends React.Component {
 
     this.boundActions = bindActionCreators(searchActions, dispatch);
   }
+  componentDidUpdate() {
+    ReactDOM.findDOMNode(this).scrollIntoView();
+  }
 
   render() {
     const { query } = (this.props.location) ? queryString.stringify(queryString.parse(this.props.location)) : '';
-    const userQuery = (query && query.q) ? query.q : '';
+    const searchQuery = (query && query.q) ? query.q : this.props.searchQuery;
     const selectedField = (query && query.field) ? query.field : this.props.searchField;
     const pageType = (_isEmpty(this.props.searchResults)) ? 'home' : 'results';
 
@@ -36,7 +40,7 @@ class SearchContainer extends React.Component {
       <main id="mainContent">
         <div className="nypl-full-width-wrapper">
           <div className="nypl-page-header">
-            <Breadcrumbs query={userQuery} type={pageType} />
+            <Breadcrumbs query={this.props.searchQuery} type={pageType} />
           </div>
           <div role="search" aria-label="ResearchNow">
             <div className="nypl-row">
@@ -50,8 +54,9 @@ class SearchContainer extends React.Component {
             </div>
             <div className="wrapper">
               <SearchForm
-                searchQuery={userQuery}
+                searchQuery={searchQuery}
                 searchField={selectedField}
+                history={this.context.history}
                 {...this.boundActions}
               />
               <SearchResults
@@ -79,7 +84,7 @@ SearchContainer.propTypes = {
 SearchContainer.defaultProps = {
   searchResults: {},
   searchQuery: '',
-  searchField: '',
+  searchField: 'keyword',
   workDetail: {},
   dispatch: () => {},
   eReaderUrl: '',
@@ -87,13 +92,14 @@ SearchContainer.defaultProps = {
 
 SearchContainer.contextTypes = {
   router: PropTypes.object,
+  history: PropTypes.object,
 };
 
 const mapStateToProps = (state, ownProps) => {
   return {
     searchResults: state.searchResults,
-    searchQuery: state.searchQuery || ownProps.q,
-    searchField: state.searchField || ownProps.field,
+    searchQuery: state.userQuery || ownProps.q,
+    searchField: state.selectedField || ownProps.field,
   };
 };
 

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -27,7 +26,7 @@ class SearchContainer extends React.Component {
   }
 
   componentDidUpdate() {
-    ReactDOM.findDOMNode(this).scrollIntoView();
+    window.scrollTo(0, 0);
   }
 
   /**
@@ -39,7 +38,7 @@ class SearchContainer extends React.Component {
   handleReset(event) {
     event.preventDefault();
 
-    searchActions.resetSearch();
+    this.boundActions.resetSearch();
     this.context.router.push('/');
   }
 
@@ -119,9 +118,9 @@ SearchContainer.contextTypes = {
 
 const mapStateToProps = (state, ownProps) => (
   {
-    searchResults: state.searchResults,
-    searchQuery: state.userQuery || ownProps.searchQuery,
-    searchField: state.selectedField || ownProps.searchField,
+    searchResults: state.searchResults || ownProps.searchResults,
+    searchQuery: state.searchQuery || ownProps.searchQuery,
+    searchField: state.searchField || ownProps.searchField,
   }
 );
 

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
+import queryString from 'query-string';
+import { isEmpty as _isEmpty } from 'underscore';
 import SearchForm from '../SearchForm/SearchForm';
 import SearchResults from '../SearchResults/SearchResults';
 import * as searchActions from '../../actions/SearchActions';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 
 /**
  * Container class providing the Redux action creators
@@ -24,35 +27,39 @@ class SearchContainer extends React.Component {
   }
 
   render() {
-    const { query } = (this.props.location) ? this.props.location : '';
-    const userQuery = (query && query.q) ? query.q : this.props.searchQuery;
+    const { query } = (this.props.location) ? queryString.stringify(queryString.parse(this.props.location)) : '';
+    const userQuery = (query && query.q) ? query.q : '';
     const selectedField = (query && query.field) ? query.field : this.props.searchField;
+    const pageType = (_isEmpty(this.props.searchResults)) ? 'home' : 'results';
+
     return (
       <main id="mainContent">
-        <div className="nypl-page-header">
-          <nav aria-label="Breadcrumbs" className="nypl-breadcrumbs" />
-        </div>
-        <div className="nypl-full-width-wrapper" role="search" aria-label="ResearchNow">
-          <div className="nypl-row">
-            <div className="nypl-column-full">
-              <h1 className="nypl-heading">ResearchNow</h1>
-              <div id="tagline">
-                Search the world&apos;s research collections and more for digital books you
-                can use right now.
+        <div className="nypl-full-width-wrapper">
+          <div className="nypl-page-header">
+            <Breadcrumbs query={userQuery} type={pageType} />
+          </div>
+          <div role="search" aria-label="ResearchNow">
+            <div className="nypl-row">
+              <div className="nypl-column-full">
+                <h1 className="nypl-heading">ResearchNow</h1>
+                <div id="tagline">
+                  Search the world&apos;s research collections and more for digital books you
+                  can use right now.
+                </div>
               </div>
             </div>
-          </div>
-          <div className="wrapper">
-            <SearchForm
-              searchQuery={userQuery}
-              searchField={selectedField}
-              {...this.boundActions}
-            />
-            <SearchResults
-              results={this.props.searchResults}
-              eReaderUrl={this.props.eReaderUrl}
-              {...this.boundActions}
-            />
+            <div className="wrapper">
+              <SearchForm
+                searchQuery={userQuery}
+                searchField={selectedField}
+                {...this.boundActions}
+              />
+              <SearchResults
+                results={this.props.searchResults}
+                eReaderUrl={this.props.eReaderUrl}
+                {...this.boundActions}
+              />
+            </div>
           </div>
         </div>
       </main>

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -25,6 +25,7 @@ class SearchContainer extends React.Component {
 
     this.boundActions = bindActionCreators(searchActions, dispatch);
   }
+
   componentDidUpdate() {
     ReactDOM.findDOMNode(this).scrollIntoView();
   }
@@ -39,7 +40,7 @@ class SearchContainer extends React.Component {
       <main id="mainContent">
         <div className="nypl-full-width-wrapper">
           <div className="nypl-page-header">
-            <Breadcrumbs query={this.props.searchQuery} type={pageType} />
+            <Breadcrumbs query={this.props.searchQuery} pageType={pageType} />
           </div>
           <div role="search" aria-label="ResearchNow">
             <div className="nypl-row">

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router';
-import queryString from 'query-string';
 import { isEmpty as _isEmpty } from 'underscore';
 import SearchForm from '../SearchForm/SearchForm';
 import SearchResults from '../SearchResults/SearchResults';
@@ -31,7 +30,7 @@ class SearchContainer extends React.Component {
   }
 
   render() {
-    const { query } = (this.props.location) ? queryString.stringify(queryString.parse(this.props.location)) : '';
+    const { query } = this.props.location;
     const searchQuery = (query && query.q) ? query.q : this.props.searchQuery;
     const selectedField = (query && query.field) ? query.field : this.props.searchField;
     const pageType = (_isEmpty(this.props.searchResults)) ? 'home' : 'results';
@@ -79,6 +78,7 @@ SearchContainer.propTypes = {
   workDetail: PropTypes.object,
   dispatch: PropTypes.func,
   eReaderUrl: PropTypes.string,
+  location: PropTypes.object,
 };
 
 SearchContainer.defaultProps = {
@@ -88,6 +88,7 @@ SearchContainer.defaultProps = {
   workDetail: {},
   dispatch: () => {},
   eReaderUrl: '',
+  location: {},
 };
 
 SearchContainer.contextTypes = {
@@ -95,13 +96,13 @@ SearchContainer.contextTypes = {
   history: PropTypes.object,
 };
 
-const mapStateToProps = (state, ownProps) => {
-  return {
+const mapStateToProps = (state, ownProps) => (
+  {
     searchResults: state.searchResults,
     searchQuery: state.userQuery || ownProps.q,
     searchField: state.selectedField || ownProps.field,
-  };
-};
+  }
+);
 
 export default connect(
   mapStateToProps,

--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -30,6 +30,19 @@ class SearchContainer extends React.Component {
     ReactDOM.findDOMNode(this).scrollIntoView();
   }
 
+  /**
+   * onClick handler for resetting state for the request back to the home page
+   * to return the user to a new search.
+   *
+   * @param {object} event
+   */
+  handleReset(event) {
+    event.preventDefault();
+
+    searchActions.resetSearch();
+    this.context.router.push('/');
+  }
+
   render() {
     const { query } = this.props.location;
     const searchQuery = (query && query.q) ? query.q : this.props.searchQuery;
@@ -40,7 +53,14 @@ class SearchContainer extends React.Component {
       <main id="mainContent">
         <div className="nypl-full-width-wrapper">
           <div className="nypl-page-header">
-            <Breadcrumbs query={this.props.searchQuery} pageType={pageType} />
+            <Breadcrumbs
+              links={[{
+                href: `/search?q=${searchQuery}&field=${selectedField}`,
+                text: 'Search Results',
+              }]}
+              pageType={pageType}
+              onClickHandler={this.handleReset.bind(this)}
+            />
           </div>
           <div role="search" aria-label="ResearchNow">
             <div className="nypl-row">
@@ -100,8 +120,8 @@ SearchContainer.contextTypes = {
 const mapStateToProps = (state, ownProps) => (
   {
     searchResults: state.searchResults,
-    searchQuery: state.userQuery || ownProps.q,
-    searchField: state.selectedField || ownProps.field,
+    searchQuery: state.userQuery || ownProps.searchQuery,
+    searchField: state.selectedField || ownProps.searchField,
   }
 );
 

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -61,7 +61,7 @@ class SearchForm extends React.Component {
                     <select
                       id="search-by-field"
                       onChange={this.onFieldChange}
-                      value={this.props.searchField}
+                      value={this.state.searchField}
                     >
                       {this.props.allowedFields.map((field, key) => {
                         return (

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -16,6 +16,21 @@ class SearchForm extends React.Component {
     this.submitSearchRequest = this.submitSearchRequest.bind(this);
   }
 
+  /**
+   * Used to update the downstream props updated by the
+   * parent component, SearchContainer.
+   *
+   * @param {object} nextProps
+   */
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.searchQuery !== this.props.searchQuery) {
+      this.setState({ searchQuery: nextProps.searchQuery });
+    }
+    if (nextProps.searchField !== this.props.searchField) {
+      this.setState({ searchField: nextProps.searchField });
+    }
+  }
+
   onFieldChange(event) {
     const fieldSelected = event.target.value;
     this.setState({ searchField: fieldSelected });
@@ -27,6 +42,8 @@ class SearchForm extends React.Component {
 
   handleSubmit(event) {
     if (event && event.charCode === 13) {
+      this.props.selectedField(this.state.searchField);
+      this.props.userQuery(this.state.searchQuery);
       this.submitSearchRequest(event);
     }
   }
@@ -39,8 +56,6 @@ class SearchForm extends React.Component {
 
     const terms = this.state.searchQuery.trim().replace(/\s+/g, ' ');
 
-    this.props.userQuery(terms);
-    this.props.selectedField(this.state.searchField);
     this.props.searchPost(terms, this.state.searchField)
       .then(() => {
         const encodedUserInput = encodeURIComponent(terms);

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEmpty as _isEmpty } from 'underscore';
 import { titleCase } from 'change-case';
 import SearchButton from '../Button/SearchButton';
 
@@ -32,17 +33,14 @@ class SearchForm extends React.Component {
 
   submitSearchRequest(event) {
     event.preventDefault();
-    if (!this.state.searchField) {
-      this.setState({ searchField: 'keyword' });
-    }
     if (!this.state.searchQuery) {
       throw new Error('Please enter a term or terms to search');
     }
 
     const terms = this.state.searchQuery.trim().replace(/\s+/g, ' ');
 
-    this.props.setQuery(terms);
-    this.props.setField(this.state.searchField);
+    this.props.userQuery(terms);
+    this.props.selectedField(this.state.searchField);
     this.props.searchPost(terms, this.state.searchField)
       .then(() => {
         const encodedUserInput = encodeURIComponent(terms);
@@ -63,7 +61,7 @@ class SearchForm extends React.Component {
                     <select
                       id="search-by-field"
                       onChange={this.onFieldChange}
-                      value={this.state.searchField}
+                      value={this.props.searchField}
                     >
                       {this.props.allowedFields.map((field, key) => {
                         return (
@@ -118,11 +116,12 @@ SearchForm.defaultProps = {
     'subject',
   ],
   searchQuery: '',
-  searchField: '',
+  searchField: 'keyword',
 };
 
 SearchForm.contextTypes = {
   router: PropTypes.object,
+  history: PropTypes.object,
 };
 
 export default SearchForm;

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -16,6 +16,10 @@ class SearchForm extends React.Component {
     this.submitSearchRequest = this.submitSearchRequest.bind(this);
   }
 
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
   /**
    * Used to update the downstream props updated by the
    * parent component, SearchContainer.

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -41,6 +41,8 @@ class SearchForm extends React.Component {
 
     const terms = this.state.searchQuery.trim().replace(/\s+/g, ' ');
 
+    this.props.setQuery(terms);
+    this.props.setField(this.state.searchField);
     this.props.searchPost(terms, this.state.searchField)
       .then(() => {
         const encodedUserInput = encodeURIComponent(terms);

--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { isEmpty as _isEmpty } from 'underscore';
 import EBookList from '../List/EBookList';
-import { searchPost } from '../../actions/SearchActions';
+import { searchPost, userQuery, selectedField } from '../../actions/SearchActions';
 
 const elements = ['title', 'entities', 'instances', 'subjects', 'rights_stmt', 'language'];
 export const labels = {
@@ -32,6 +32,8 @@ export const DefinitionList = (props) => {
   const newSearchRequest = (event, query, field) => {
     event.preventDefault();
 
+    props.dispatch(userQuery(query));
+    props.dispatch(selectedField(field));
     props.dispatch(searchPost(query, field))
       .then(() => {
         props.context.router.push(`/search?q=${query}&field=${field}`);

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { isEmpty as _isEmpty } from 'underscore';
 import { DefinitionList } from './DefinitionList';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
+import * as searchActions from '../../actions/SearchActions';
 
 class WorkDetail extends React.Component {
 
@@ -26,6 +27,19 @@ class WorkDetail extends React.Component {
     ));
   };
 
+
+  /**
+   * onClick handler for resetting state for the request back to the home page
+   * to return the user to a new search.
+   *
+   * @param {object} event
+   */
+  handleReset(event) {
+    searchActions.userQuery('');
+    searchActions.selectedField('');
+    searchActions.searchResults('');
+  }
+
   render() {
     if (!this.props.work && _isEmpty(this.props.work)) {
       throw new Error('Work prop is missing or empty');
@@ -39,7 +53,8 @@ class WorkDetail extends React.Component {
             <Breadcrumbs
               query={this.props.searchQuery}
               field={this.props.searchField}
-              type="details"
+              pageType="details"
+              handleReset={this.handleReset}
             />
           </div>
           <div className="nypl-row">

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -31,12 +31,16 @@ class WorkDetail extends React.Component {
       throw new Error('Work prop is missing or empty');
     }
     const { work } = this.props;
-    console.log('detail props', this.props);
+
     return (
       <main id="mainContent">
         <div className="nypl-full-width-wrapper">
           <div className="nypl-page-header">
-            <Breadcrumbs query={this.props.searchQuery} field={this.props.searchField} type="details" />
+            <Breadcrumbs
+              query={this.props.searchQuery}
+              field={this.props.searchField}
+              type="details"
+            />
           </div>
           <div className="nypl-row">
             <div className="nypl-column-full">
@@ -76,14 +80,13 @@ WorkDetail.contextTypes = {
   history: PropTypes.object,
 };
 
-const mapStateToProps = (state, ownProps) => {
-  console.log('state in detail', state);
-  return {
+const mapStateToProps = (state, ownProps) => (
+  {
     work: state.workDetail && state.workDetail.work,
-    searchQuery: state.userQuery,
-    searchField: state.selectedField,
-  };
-};
+    searchQuery: state.userQuery || ownProps.searchQuery,
+    searchField: state.selectedField || ownProps.searchField,
+  }
+);
 
 export default connect(
   mapStateToProps,

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -31,7 +31,7 @@ class WorkDetail extends React.Component {
     return Object.keys(work).map(key => (
       [key, work[key]]
     ));
-  };
+  }
 
   /**
    * onClick handler for resetting state for the request back to the home page

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
@@ -7,6 +8,10 @@ import { DefinitionList } from './DefinitionList';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 
 class WorkDetail extends React.Component {
+
+  componentDidMount() {
+    ReactDOM.findDOMNode(this).scrollIntoView();
+  }
 
   /**
    * Convert JSON object to array for parsing detail elements into
@@ -26,15 +31,12 @@ class WorkDetail extends React.Component {
       throw new Error('Work prop is missing or empty');
     }
     const { work } = this.props;
-    // Rewind to previous results page query and parse for Breadcrumbs.
-    const resultsQuery = this.props.location.history.query;
-    console.log('History?', resultsQuery);
-
+    console.log('detail props', this.props);
     return (
       <main id="mainContent">
         <div className="nypl-full-width-wrapper">
           <div className="nypl-page-header">
-            <Breadcrumbs query={resultsQuery} type="details" />
+            <Breadcrumbs query={this.props.searchQuery} field={this.props.searchField} type="details" />
           </div>
           <div className="nypl-row">
             <div className="nypl-column-full">
@@ -57,25 +59,29 @@ class WorkDetail extends React.Component {
 
 WorkDetail.propTypes = {
   work: PropTypes.object,
-  query: PropTypes.string,
+  searchQuery: PropTypes.string,
+  searchField: PropTypes.string,
   eReaderUrl: PropTypes.string,
 };
 
 WorkDetail.defaultProps = {
   work: {},
-  query: '',
+  searchQuery: '',
+  searchField: '',
   eReaderUrl: '',
 };
 
 WorkDetail.contextTypes = {
   router: PropTypes.object,
+  history: PropTypes.object,
 };
 
 const mapStateToProps = (state, ownProps) => {
   console.log('state in detail', state);
   return {
     work: state.workDetail && state.workDetail.work,
-    query: state.setQuery,
+    searchQuery: state.userQuery,
+    searchField: state.selectedField,
   };
 };
 

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -1,17 +1,23 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { isEmpty as _isEmpty } from 'underscore';
 import { DefinitionList } from './DefinitionList';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import * as searchActions from '../../actions/SearchActions';
 
 class WorkDetail extends React.Component {
+  constructor(props) {
+    super(props);
+    const { dispatch } = props;
+
+    this.boundActions = bindActionCreators(searchActions, dispatch);
+  }
 
   componentDidMount() {
-    ReactDOM.findDOMNode(this).scrollIntoView();
+    window.scrollTo(0, 0);
   }
 
   /**
@@ -36,7 +42,7 @@ class WorkDetail extends React.Component {
   handleReset(event) {
     event.preventDefault();
 
-    searchActions.resetSearch();
+    this.boundActions.resetSearch();
     this.context.router.push('/');
   }
 
@@ -89,6 +95,7 @@ WorkDetail.propTypes = {
   searchQuery: PropTypes.string,
   searchField: PropTypes.string,
   eReaderUrl: PropTypes.string,
+  dispatch: PropTypes.func,
 };
 
 WorkDetail.defaultProps = {
@@ -96,6 +103,7 @@ WorkDetail.defaultProps = {
   searchQuery: '',
   searchField: '',
   eReaderUrl: '',
+  dispatch: () => {},
 };
 
 WorkDetail.contextTypes = {
@@ -106,8 +114,8 @@ WorkDetail.contextTypes = {
 const mapStateToProps = (state, ownProps) => (
   {
     work: state.workDetail && state.workDetail.work,
-    searchQuery: state.userQuery || ownProps.searchQuery,
-    searchField: state.selectedField || ownProps.searchField,
+    searchQuery: state.searchQuery || ownProps.searchQuery,
+    searchField: state.searchField || ownProps.searchField,
   }
 );
 

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -27,7 +27,6 @@ class WorkDetail extends React.Component {
     ));
   };
 
-
   /**
    * onClick handler for resetting state for the request back to the home page
    * to return the user to a new search.
@@ -35,9 +34,10 @@ class WorkDetail extends React.Component {
    * @param {object} event
    */
   handleReset(event) {
-    searchActions.userQuery('');
-    searchActions.selectedField('');
-    searchActions.searchResults('');
+    event.preventDefault();
+
+    searchActions.resetSearch();
+    this.context.router.push('/');
   }
 
   render() {
@@ -51,10 +51,18 @@ class WorkDetail extends React.Component {
         <div className="nypl-full-width-wrapper">
           <div className="nypl-page-header">
             <Breadcrumbs
-              query={this.props.searchQuery}
-              field={this.props.searchField}
+              links={[
+                {
+                  href: `/search?q=${this.props.searchQuery}&field=${this.props.searchField}`,
+                  text: 'Search Results',
+                },
+                {
+                  href: `/work?workId=${work.uuid}`,
+                  text: 'Work Details',
+                },
+              ]}
               pageType="details"
-              handleReset={this.handleReset}
+              onClickHandler={this.handleReset.bind(this)}
             />
           </div>
           <div className="nypl-row">

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { isEmpty as _isEmpty } from 'underscore';
 import { DefinitionList } from './DefinitionList';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 
 class WorkDetail extends React.Component {
 
@@ -25,13 +26,16 @@ class WorkDetail extends React.Component {
       throw new Error('Work prop is missing or empty');
     }
     const { work } = this.props;
+    // Rewind to previous results page query and parse for Breadcrumbs.
+    const resultsQuery = this.props.location.history.query;
+    console.log('History?', resultsQuery);
 
     return (
       <main id="mainContent">
-        <div className="nypl-page-header">
-          <nav aria-label="Breadcrumbs" className="nypl-breadcrumbs" />
-        </div>
         <div className="nypl-full-width-wrapper">
+          <div className="nypl-page-header">
+            <Breadcrumbs query={resultsQuery} type="details" />
+          </div>
           <div className="nypl-row">
             <div className="nypl-column-full">
               <h2>Work Detail</h2>
@@ -53,11 +57,13 @@ class WorkDetail extends React.Component {
 
 WorkDetail.propTypes = {
   work: PropTypes.object,
+  query: PropTypes.string,
   eReaderUrl: PropTypes.string,
 };
 
 WorkDetail.defaultProps = {
   work: {},
+  query: '',
   eReaderUrl: '',
 };
 
@@ -66,8 +72,10 @@ WorkDetail.contextTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => {
+  console.log('state in detail', state);
   return {
     work: state.workDetail && state.workDetail.work,
+    query: state.setQuery,
   };
 };
 

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -68,8 +68,8 @@ const addFieldQuery = (queryString, field = 'keyword') => {
 export const buildQueryBody = (queryObj = {}) => {
   let queryBody = {};
   if (queryObj.query) {
-    const { userQuery, field } = queryObj.query;
-    queryBody.queries = addFieldQuery(userQuery, field);
+    const { selectQuery, selectField } = queryObj.query;
+    queryBody.queries = addFieldQuery(selectQuery, selectField);
   }
 
   return queryBody;

--- a/src/app/search/query.js
+++ b/src/app/search/query.js
@@ -20,7 +20,7 @@ const addFieldQuery = (queryString, field = 'keyword') => {
   if (!queryString) {
     throw new Error('A valid query string must be passed');
   }
-  let fieldQuery = [];
+  const fieldQuery = [];
   /**
    * Strip punctuation and process spaces as plus signs for final split.
    * ES characters to escape before sending: + - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /
@@ -61,12 +61,12 @@ const addFieldQuery = (queryString, field = 'keyword') => {
  *   per_page: 10,
  *   page: 0
  * }
- * 
+ *
  * @param {object} queryObj
  * @return {object}
  */
 export const buildQueryBody = (queryObj = {}) => {
-  let queryBody = {};
+  const queryBody = {};
   if (queryObj.query) {
     const { selectQuery, selectField } = queryObj.query;
     queryBody.queries = addFieldQuery(selectQuery, selectField);

--- a/src/app/stores/InitialState.js
+++ b/src/app/stores/InitialState.js
@@ -1,7 +1,7 @@
 const initialState = {
   searchResults: {},
-  query: '*',
-  field: 'keyword',
+  userQuery: '',
+  selectedField: '',
   sort: {
     sortFilter: 'title',
     sortOrder: 'asc',

--- a/src/app/stores/InitialState.js
+++ b/src/app/stores/InitialState.js
@@ -1,7 +1,7 @@
 const initialState = {
   searchResults: {},
-  userQuery: '',
-  selectedField: '',
+  searchQuery: '',
+  searchField: '',
   sort: {
     sortFilter: 'title',
     sortOrder: 'asc',

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 import { Actions } from '../actions/SearchActions';
+import initialState from './InitialState';
 
 export const searchResults = (state = null, action) => {
   switch (action.type) {
@@ -47,6 +48,12 @@ export const sort = (state = null, action) => (
     state
 );
 
+export const resetSearch = (state = null, action) => (
+  (action.reset) ?
+    initialState :
+    state
+);
+
 export default combineReducers({
   searchResults,
   userQuery,
@@ -54,4 +61,5 @@ export default combineReducers({
   allowedFilters,
   sort,
   workDetail,
+  resetSearch,
 });

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -23,34 +23,34 @@ export const workDetail = (state = null, action) => {
   }
 };
 
-export const query = (state = null, action) => (
-  (action.payload) ?
-    action.payload.query :
+export const userQuery = (state = null, action) => (
+  (action.userQuery) ?
+    action.userQuery :
     state
 );
 
-export const field = (state = null, action) => (
-  (action.payload) ?
-    action.payload.field :
+export const selectedField = (state = null, action) => (
+  (action.selectedField) ?
+    action.selectedField :
     state
 );
 
 export const allowedFilters = (state = null, action) => (
-  (action.payload) ?
-    action.payload.allowedFilters :
+  (action.allowedFilters) ?
+    action.allowedFilters :
     state
 );
 
 export const sort = (state = null, action) => (
-  (action.payload) ?
-    action.payload.sort :
+  (action.sort) ?
+    action.sort :
     state
 );
 
 export default combineReducers({
   searchResults,
-  query,
-  field,
+  userQuery,
+  selectedField,
   allowedFilters,
   sort,
   workDetail,

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -24,23 +24,21 @@ export const workDetail = (state = null, action) => {
   }
 };
 
-export const userQuery = (state = null, action) => (
-  (action.userQuery) ?
-    action.userQuery :
-    state
-);
+export const searchQuery = (state = null, action) => {
+  if (action.type === Actions.SET_QUERY) {
+    return action.searchQuery;
+  }
 
-export const selectedField = (state = null, action) => (
-  (action.selectedField) ?
-    action.selectedField :
-    state
-);
+  return state;
+};
 
-export const allowedFilters = (state = null, action) => (
-  (action.allowedFilters) ?
-    action.allowedFilters :
-    state
-);
+export const searchField = (state = null, action) => {
+  if (action.type === Actions.SET_FIELD) {
+    return action.searchField;
+  }
+
+  return state;
+};
 
 export const sort = (state = null, action) => (
   (action.sort) ?
@@ -48,18 +46,28 @@ export const sort = (state = null, action) => (
     state
 );
 
-export const resetSearch = (state = null, action) => (
-  (action.reset) ?
-    initialState :
-    state
-);
+// export const resetSearch = (state = null, action) => {
+//   if (action.type === Actions.RESET_SEARCH) {
+//     return initialState;
+//   }
 
-export default combineReducers({
+//   return state;
+// };
+
+const appReducer = combineReducers({
   searchResults,
-  userQuery,
-  selectedField,
-  allowedFilters,
+  searchQuery,
+  searchField,
   sort,
   workDetail,
-  resetSearch,
 });
+
+export const rootReducer = (state, action) => {
+  if (action.type === Actions.RESET_SEARCH) {
+    state = initialState;
+  }
+
+  return appReducer(state, action);
+};
+
+export default rootReducer;

--- a/src/app/stores/Reducers.js
+++ b/src/app/stores/Reducers.js
@@ -46,14 +46,6 @@ export const sort = (state = null, action) => (
     state
 );
 
-// export const resetSearch = (state = null, action) => {
-//   if (action.type === Actions.RESET_SEARCH) {
-//     return initialState;
-//   }
-
-//   return state;
-// };
-
 const appReducer = combineReducers({
   searchResults,
   searchQuery,
@@ -64,7 +56,7 @@ const appReducer = combineReducers({
 
 export const rootReducer = (state, action) => {
   if (action.type === Actions.RESET_SEARCH) {
-    state = initialState;
+    return initialState;
   }
 
   return appReducer(state, action);

--- a/src/app/stores/ReduxStore.js
+++ b/src/app/stores/ReduxStore.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import searchReducer from './Reducers';
+import { rootReducer } from './Reducers';
 
-export default createStore(searchReducer, applyMiddleware(thunk));
+export default createStore(rootReducer, applyMiddleware(thunk));

--- a/src/app/stores/configureStore.js
+++ b/src/app/stores/configureStore.js
@@ -1,6 +1,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
-import searchReducer from './Reducers';
+import { rootReducer } from './Reducers';
 
 /**
  * Provides a configurable store object that uses enhancers
@@ -18,7 +18,7 @@ export default function configureStore(preloadedState) {
   const enhancers = [middlewareEnhancer];
   const composedEnhancers = compose(...enhancers);
 
-  const store = createStore(searchReducer, preloadedState, composedEnhancers);
+  const store = createStore(rootReducer, preloadedState, composedEnhancers);
 
   return store;
 }

--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import a11y from 'react-a11y';
 import ReactDOM from 'react-dom';
-// import createBrowserHistory from 'history/lib/createBrowserHistory';
-// import useScroll from 'react-router-scroll';
 import { Router, browserHistory } from 'react-router';
 import { Provider } from 'react-redux';
 import configureStore from '../app/stores/configureStore';
@@ -16,7 +14,6 @@ if (loadA11y) {
 }
 
 window.onload = () => {
-  const appHistory = browserHistory;
   const appElement = document.getElementById('app');
   const preloadedState = window.__PRELOADED_STATE__;
 
@@ -26,7 +23,7 @@ window.onload = () => {
 
   ReactDOM.render(
     <Provider store={store}>
-      <Router history={appHistory}>{routes.default}</Router>
+      <Router history={browserHistory}>{routes.default}</Router>
     </Provider>,
     appElement,
   );

--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -28,3 +28,7 @@ $nypl-dark-blue: #135772;
   text-align: center;
   margin: 25px 0;
 }
+
+.nypl-page-header {
+  background-color: white;
+}

--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -13,14 +13,14 @@ export const searchServer = (req, res, next) => {
         res.data = data;
         next();
       })
-      .catch((err) => console.log('serverFetchWork failed', err.message));
+      .catch(err => console.log('serverFetchWork failed', err.message));
   } else {
     serverPost(q, field)
       .then((data) => {
         res.data = data;
         next();
       })
-      .catch((err) => console.log('serverPost failed', err.message));
+      .catch(err => console.log('serverPost failed', err.message));
   }
 };
 

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -91,7 +91,7 @@ describe('Breadcrumbs', () => {
       expect(detailLinks.at(0).children().text()).to.equal('ResearchNow');
       expect(detailLinks.at(0).prop('to')).to.equal('/');
       expect(detailLinks.at(1).children().text()).to.equal('Search Results');
-      expect(detailLinks.at(1).prop('to')).to.equal('/search?q=journey&field=title');
+      expect(detailLinks.at(1).prop('href')).to.equal('/search?q=journey&field=title');
     });
 
     it('should display a crumb for the details page without being a link', () => {

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -7,12 +7,18 @@ import Breadcrumbs from '../../src/app/components/Breadcrumbs/Breadcrumbs';
 describe('Breadcrumbs', () => {
   describe('On render all crumbs', () => {
     let component;
-    const query = 'journey';
-    const field = 'keyword';
+    const links = [{
+      href: '/search?q=journey&field=keyword',
+      text: 'Search Results',
+    },
+    {
+      href: '/work?workId=foobar',
+      text: 'Work Details',
+    }];
     const pageType = 'details';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
+      component = shallow(<Breadcrumbs links={links} pageType={pageType} />);
     });
 
     it('should render a nav and ol element', () => {
@@ -28,12 +34,11 @@ describe('Breadcrumbs', () => {
 
   describe('On the home page', () => {
     let component;
-    const query = '';
-    const field = 'keyword';
+    const links = [{ href: '', text: '' }];
     const pageType = 'home';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
+      component = shallow(<Breadcrumbs links={links} pageType={pageType} />);
     });
 
     it('should display no breadcrumb nav element', () => {
@@ -43,12 +48,14 @@ describe('Breadcrumbs', () => {
 
   describe('On the results page', () => {
     let component;
-    const query = 'journey';
-    const field = 'keyword';
+    const links = [{
+      href: '/search?q=journey&field=keyword',
+      text: 'Search Results',
+    }];
     const pageType = 'results';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
+      component = shallow(<Breadcrumbs links={links} pageType={pageType} />);
     });
 
     it('should display a link back to the home page', () => {
@@ -64,12 +71,18 @@ describe('Breadcrumbs', () => {
 
   describe('On the details page', () => {
     let component;
-    const query = 'journey';
-    const field = 'title';
+    const links = [{
+      href: '/search?q=journey&field=title',
+      text: 'Search Results',
+    },
+    {
+      href: '/work?workId=foobar',
+      text: 'Work Details',
+    }];
     const pageType = 'details';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
+      component = shallow(<Breadcrumbs links={links} pageType={pageType} />);
     });
 
     it('should display a link back to the results page and home page', () => {
@@ -82,7 +95,7 @@ describe('Breadcrumbs', () => {
     });
 
     it('should display a crumb for the details page without being a link', () => {
-      expect(component.find('li').at(2).text()).to.equal('Work Detail');
+      expect(component.find('li').at(2).text()).to.equal('Work Details');
     });
   });
 });

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -1,0 +1,86 @@
+/* eslint-env mocha */
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import Breadcrumbs from '../../src/app/components/Breadcrumbs/Breadcrumbs';
+
+describe('Breadcrumbs', () => {
+  describe('On render all crumbs', () => {
+    let component;
+    const query = 'q=journey';
+    const workUrl = 'workId=some-uuid-value';
+    const type = 'details';
+
+    before(() => {
+      component = shallow(<Breadcrumbs query={query} type={type} workUrl={workUrl} />);
+    });
+
+    it('should render a nav and ol element', () => {
+      expect(component.find('nav').length).to.equal(1);
+      expect(component.find('ol').length).to.equal(1);
+    });
+
+    it('should have three list items and two links', () => {
+      expect(component.find('li').length).to.equal(3);
+      expect(component.find('Link').length).to.equal(2);
+    });
+  });
+
+  describe('On the home page', () => {
+    let component;
+    const query = '';
+    const type = 'home';
+
+    before(() => {
+      component = shallow(<Breadcrumbs query={query} type={type} />);
+    });
+
+    it('should display no breadcrumb nav element', () => {
+      expect(component).to.be.unrendered;
+    });
+  });
+
+  describe('On the results page', () => {
+    let component;
+    const query = 'q=journey&field=keyword';
+    const type = 'results';
+
+    before(() => {
+      component = shallow(<Breadcrumbs query={query} type={type} />);
+    });
+
+    it('should display a link back to the home page', () => {
+      const resultsLinks = component.find('Link');
+      expect(resultsLinks.length).to.equal(1);
+      expect(resultsLinks.at(0).children().text()).to.equal('ResearchNow');
+    });
+
+    it('should display a crumb for the results page without being a link', () => {
+      expect(component.find('li').at(1).text()).to.equal('Search Results');
+    });
+  });
+
+  describe('On the details page', () => {
+    let component;
+    const query = 'journey';
+    const workUrl = 'workId=some-uuid-value';
+    const type = 'details';
+
+    before(() => {
+      component = shallow(<Breadcrumbs query={query} type={type} workUrl={workUrl} />);
+    });
+
+    it('should display a link back to the results page and home page', () => {
+      const detailLinks = component.find('Link');
+      expect(detailLinks.length).to.equal(2);
+      expect(detailLinks.at(0).children().text()).to.equal('ResearchNow');
+      expect(detailLinks.at(0).prop('to')).to.equal('/');
+      expect(detailLinks.at(1).children().text()).to.equal('Search Results');
+      expect(detailLinks.at(1).prop('to')).to.equal('/search?q=journey');
+    });
+
+    it('should display a crumb for the details page without being a link', () => {
+      expect(component.find('li').at(2).text()).to.equal('Work Detail');
+    });
+  });
+});

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -7,12 +7,12 @@ import Breadcrumbs from '../../src/app/components/Breadcrumbs/Breadcrumbs';
 describe('Breadcrumbs', () => {
   describe('On render all crumbs', () => {
     let component;
-    const query = 'q=journey';
-    const workUrl = 'workId=some-uuid-value';
+    const query = 'journey';
+    const field = 'keyword';
     const type = 'details';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} type={type} workUrl={workUrl} />);
+      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
     });
 
     it('should render a nav and ol element', () => {
@@ -29,10 +29,11 @@ describe('Breadcrumbs', () => {
   describe('On the home page', () => {
     let component;
     const query = '';
+    const field = 'keyword';
     const type = 'home';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} type={type} />);
+      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
     });
 
     it('should display no breadcrumb nav element', () => {
@@ -42,11 +43,12 @@ describe('Breadcrumbs', () => {
 
   describe('On the results page', () => {
     let component;
-    const query = 'q=journey&field=keyword';
+    const query = 'journey';
+    const field = 'keyword';
     const type = 'results';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} type={type} />);
+      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
     });
 
     it('should display a link back to the home page', () => {
@@ -63,11 +65,11 @@ describe('Breadcrumbs', () => {
   describe('On the details page', () => {
     let component;
     const query = 'journey';
-    const workUrl = 'workId=some-uuid-value';
+    const field = 'title';
     const type = 'details';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} type={type} workUrl={workUrl} />);
+      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
     });
 
     it('should display a link back to the results page and home page', () => {
@@ -76,7 +78,7 @@ describe('Breadcrumbs', () => {
       expect(detailLinks.at(0).children().text()).to.equal('ResearchNow');
       expect(detailLinks.at(0).prop('to')).to.equal('/');
       expect(detailLinks.at(1).children().text()).to.equal('Search Results');
-      expect(detailLinks.at(1).prop('to')).to.equal('/search?q=journey');
+      expect(detailLinks.at(1).prop('to')).to.equal('/search?q=journey&field=title');
     });
 
     it('should display a crumb for the details page without being a link', () => {

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -9,10 +9,10 @@ describe('Breadcrumbs', () => {
     let component;
     const query = 'journey';
     const field = 'keyword';
-    const type = 'details';
+    const pageType = 'details';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
+      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
     });
 
     it('should render a nav and ol element', () => {
@@ -30,10 +30,10 @@ describe('Breadcrumbs', () => {
     let component;
     const query = '';
     const field = 'keyword';
-    const type = 'home';
+    const pageType = 'home';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
+      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
     });
 
     it('should display no breadcrumb nav element', () => {
@@ -45,10 +45,10 @@ describe('Breadcrumbs', () => {
     let component;
     const query = 'journey';
     const field = 'keyword';
-    const type = 'results';
+    const pageType = 'results';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
+      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
     });
 
     it('should display a link back to the home page', () => {
@@ -66,10 +66,10 @@ describe('Breadcrumbs', () => {
     let component;
     const query = 'journey';
     const field = 'title';
-    const type = 'details';
+    const pageType = 'details';
 
     before(() => {
-      component = shallow(<Breadcrumbs query={query} field={field} type={type} />);
+      component = shallow(<Breadcrumbs query={query} field={field} pageType={pageType} />);
     });
 
     it('should display a link back to the results page and home page', () => {

--- a/test/unit/Breadcrumbs.test.js
+++ b/test/unit/Breadcrumbs.test.js
@@ -26,9 +26,12 @@ describe('Breadcrumbs', () => {
       expect(component.find('ol').length).to.equal(1);
     });
 
-    it('should have three list items and two links', () => {
+    it('should have three list items having two links and one string', () => {
       expect(component.find('li').length).to.equal(3);
       expect(component.find('Link').length).to.equal(2);
+      const linkObjects = component.find('Link');
+      expect(linkObjects.at(0).prop('to')).to.equal('/');
+      expect(linkObjects.at(1).prop('to')).to.equal('/search?q=journey&field=keyword');
     });
   });
 
@@ -66,6 +69,7 @@ describe('Breadcrumbs', () => {
 
     it('should display a crumb for the results page without being a link', () => {
       expect(component.find('li').at(1).text()).to.equal('Search Results');
+      expect(component.find('li').at(1).find('Link').length).to.equal(0);
     });
   });
 
@@ -91,11 +95,12 @@ describe('Breadcrumbs', () => {
       expect(detailLinks.at(0).children().text()).to.equal('ResearchNow');
       expect(detailLinks.at(0).prop('to')).to.equal('/');
       expect(detailLinks.at(1).children().text()).to.equal('Search Results');
-      expect(detailLinks.at(1).prop('href')).to.equal('/search?q=journey&field=title');
+      expect(detailLinks.at(1).prop('to')).to.equal('/search?q=journey&field=title');
     });
 
     it('should display a crumb for the details page without being a link', () => {
       expect(component.find('li').at(2).text()).to.equal('Work Details');
+      expect(component.find('li').at(2).find('Link').length).to.equal(0);
     });
   });
 });

--- a/test/unit/Query.test.js
+++ b/test/unit/Query.test.js
@@ -6,7 +6,7 @@ describe('Query Body Building', () => {
   let query;
 
   beforeEach(() => {
-    query = { query: { userQuery: "$shakespeare's, 1632-1635 +hamlet gh:ost; select * && delete * || drop *", field: 'title' } };
+    query = { query: { selectQuery: "$shakespeare's, 1632-1635 +hamlet gh:ost; select * && delete * || drop *", selectField: 'title' } };
   });
 
   it('should not contain certain punctuation', () => {
@@ -24,7 +24,7 @@ describe('Query Body Building', () => {
   });
 
   it('should return field query object with a single string value.', () => {
-    query = { query: { userQuery: 'shakespeare', field: 'title' } };
+    query = { query: { selectQuery: 'shakespeare', selectField: 'title' } };
     const queryBody = buildQueryBody(query);
     expect(queryBody.queries.length).to.equal(1);
     const queryString = queryBody.queries[0].value;
@@ -39,7 +39,7 @@ describe('Query Body Building', () => {
   });
 
   it('should return default field when the default query string is given', () => {
-    const emptyQuery = { query: { userQuery: '*' } };
+    const emptyQuery = { query: { selectQuery: '*' } };
     const defaultQueryBody = buildQueryBody(emptyQuery);
 
     expect(defaultQueryBody).to.not.equal({});

--- a/test/unit/SearchContainer.test.js
+++ b/test/unit/SearchContainer.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import React from 'react';
 import { expect } from 'chai';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import SearchContainer from '../../src/app/components/SearchContainer/SearchContainer';
 import SearchForm from '../../src/app/components/SearchForm/SearchForm';

--- a/test/unit/SearchContainer.test.js
+++ b/test/unit/SearchContainer.test.js
@@ -23,7 +23,7 @@ describe('Search Container interactions', () => {
   it('contains an initialized <SearchForm /> component', () => {
     expect(wrapper.find(SearchForm)).to.have.length(1);
     expect(wrapper.find(SearchForm).prop('searchQuery')).to.equal('');
-    expect(wrapper.find(SearchForm).prop('searchField')).to.equal('');
+    expect(wrapper.find(SearchForm).prop('searchField')).to.equal('keyword');
   });
   it('contains a <SearchResults /> component', () => {
     expect(wrapper.find(SearchResults)).to.have.length(1);


### PR DESCRIPTION
The breadcrumbs component adds links in a trail from the home page of ResearchNow to the details view. One should be able to navigate back to either the search results one just came from if on a detail page, or back to the home page with a fresh start. Breadcrumbs should work the same whether or not the search was initiated from the form, a browse link, or a request via the address bar, e.g. /search?q=journey&field=title. Includes tests and some inline documentation.