### PR TITLE
SFR-474: Adds title and aria-labelledby elements for decorative book svgs

### DIFF
--- a/src/app/components/Svgs/BookSvg.jsx
+++ b/src/app/components/Svgs/BookSvg.jsx
@@ -10,7 +10,11 @@ const BookSvg = ({ fill = 'black', className }) => (
     xmlns="http://www.w3.org/2000/svg"
     className={className}
     fill="none"
+    alt=""
+    role="img"
+    aria-labelledby="BookIcon"
   >
+    <title id="BookIcon">Book Icon</title>
     <path
       fillRule="evenodd"
       clipRule="evenodd"

--- a/src/app/components/Svgs/EmptySearchSvg.jsx
+++ b/src/app/components/Svgs/EmptySearchSvg.jsx
@@ -10,7 +10,10 @@ const EmptySearchSvg = ({ className }) => (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
     className={className}
+    role="img"
+    aria-labelledby="SearchBookIcon"
   >
+    <title id="SearchBookIcon">No Search Results Icon</title>
     <path
       fillRule="evenodd"
       clipRule="evenodd"


### PR DESCRIPTION
After talking about it with @nachocs, I didn't add them as editable strings you can manipulate in the `<BookSvg />` element as they only refer to that particular image (seemed like overkill).