### PR TITLE
SFR-466: Removes duplicate search role

### DIFF
--- a/src/app/components/SearchContainer/SearchContainer.jsx
+++ b/src/app/components/SearchContainer/SearchContainer.jsx
@@ -97,7 +97,6 @@ class SearchContainer extends React.Component {
             />
           </div>
           <div
-            role="search"
             aria-label="ResearchNow"
             className="grid-col-12"
           >


### PR DESCRIPTION
Removes it from the search container to match the pattern of the search results page.