### PR TITLE
SFR-575 Advanced Search - refreshing page triggers Internal Server Error

### DIFF
--- a/src/server/ApiRoutes/Search.js
+++ b/src/server/ApiRoutes/Search.js
@@ -14,14 +14,20 @@ export const searchServer = (req, res, next) => {
         res.data = data;
         next();
       })
-      .catch(err => console.log('serverFetchWork failed', err.message));
+      .catch((err) => {
+        console.log('serverFetchWork failed', err.message);
+        next();
+      });
   } else {
     serverPost(searchQuery)
       .then((data) => {
         res.data = data;
         next();
       })
-      .catch(err => console.log('serverPost failed', err.message));
+      .catch((err) => {
+        console.log('serverPost failed', err.message);
+        next();
+      });
   }
 };
 


### PR DESCRIPTION
On the server side, there is a state when the url have an invalid query (like start year after end year), that triggers a server error internally and the app blocks itself in the server side.
With this change, it triggers a server error (that is ok as it's invalid query), but the app can keep on working.
Not really sure if it's related to the ticket, as I couldn't reproduce it, but anyway an improvement. Probably any error should be logged in the future.