### PR TITLE
IDs shouldn't show up in visible labels

### DIFF
--- a/src/app/components/List/EBookList.jsx
+++ b/src/app/components/List/EBookList.jsx
@@ -27,7 +27,8 @@ const generateLink = (url, eReaderUrl, local, download, ebook) => {
 // generates an array of options for the dropdown
 const generateOption = (link, eReaderUrl) => {
   const url = link.local && link.ebook && !link.download ? `${eReaderUrl}?url=${link.url}` : `${link.url}`;
-  const label = link.unique_id + link.label;
+  const uniqueId = link.unique_id;
+  const label = link.label;
   let className;
   if (!link.local) {
     className = 'external';
@@ -35,7 +36,7 @@ const generateOption = (link, eReaderUrl) => {
   return {
     value: label,
     url,
-    label,
+    uniqueId,
     title: url,
     ariaLabel: label,
     className,

--- a/src/app/libraries/react-dropdown-aria.jsx
+++ b/src/app/libraries/react-dropdown-aria.jsx
@@ -100,14 +100,14 @@ OptionItem.propTypes = {
 function defaultOptionRenderer(selectedOption, options, selectedOptionClassName, optionClassName, onOptionClicked, elementsRef, getStyle) {
   return options.map((option) => {
     const {
-      groupOptions, label, value, className,
+      groupOptions, uniqueId, value, className,
     } = option;
 
     if (groupOptions) {
       // Is group of options
       return React.createElement(
         'div',
-        { key: label, className: getStyle('groupContainer') },
+        { key: uniqueId, className: getStyle('groupContainer') },
         React.createElement(
           'div',
           { className: getStyle('groupHeading') },


### PR DESCRIPTION
Introduced a bug in the last commit.  This approach, where the label is decoupled from the key, is better.  