### PR TITLE
SFR-594 Add new analytics property

### DIFF
--- a/appConfig.js
+++ b/appConfig.js
@@ -20,4 +20,8 @@ export default {
     apiUrl: '/utils/totals',
     experimentName: 'BooksCount',
   },
+  analytics: {
+    development: 'UA-1420324-149',
+    production: 'UA-1420324-149',
+  }
 };

--- a/server.js
+++ b/server.js
@@ -84,7 +84,7 @@ app.get('/*', (req, res) => {
         appData: JSON.stringify(res.data).replace(/</g, '\\u003c'),
         appTitle,
         favicon: appConfig.favIconPath,
-        gaCode: analyticsConfig.google.code(isProduction),
+        gaCode: process.env.APP_ENV === 'production' ? appConfig.analytics.production : appConfig.analytics.development,
         webpackPort: WEBPACK_DEV_PORT,
         appEnv: process.env.APP_ENV,
         apiUrl: '',


### PR DESCRIPTION
This adds the new ResearchNow-specific Google Analytics code, replacing the default NYPL code that is brought in through the `dgx-react-ga` component. That library is still used to load the code/provide other functionality. Two options for different ga codes are provided: `production` and `development` but one code is used for both for now. In the future it will be possible to specify different properties for different versions of the app