### PR TITLE
SFR-595 Add ga tracker for pages

### DIFF
--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -2,6 +2,7 @@ import '@babel/polyfill';
 import React from 'react';
 import a11y from 'react-a11y';
 import ReactDOM from 'react-dom';
+import { gaUtils } from 'dgx-react-ga'
 import FeatureFlags from 'dgx-feature-flags';
 import { Router, browserHistory } from 'react-router';
 import { Provider } from 'react-redux';
@@ -20,6 +21,8 @@ const appElement = global.document.getElementById('app');
 if (!window.dgxFeatureFlags) {
   window.dgxFeatureFlags = FeatureFlags.utils;
 }
+
+browserHistory.listen(location => gaUtils.trackPageview(location.pathname));
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
As a single-page application ResearchNow requires a little additional configuration to track page views, and through that, search events. This can be done by hooking into the history object and listening to changes to the history, which can fire the ga tracker. With these events in ga the site search features should work automatically.

This can't be tested locally but I `console.log`'d the output of `location.pathname` on page load and it does fire properly on page changes/loads with a path that GA should understand