### PR TITLE
SFR-595 Add search params to analytics tracker

### DIFF
--- a/src/client/App.jsx
+++ b/src/client/App.jsx
@@ -22,7 +22,7 @@ if (!window.dgxFeatureFlags) {
   window.dgxFeatureFlags = FeatureFlags.utils;
 }
 
-browserHistory.listen(location => gaUtils.trackPageview(location.pathname));
+browserHistory.listen(location => gaUtils.trackPageview(`${location.pathname}${location.search}`));
 
 ReactDOM.render(
   <Provider store={store}>


### PR DESCRIPTION
This adds the URL parameters from `location.search` to the ga pageview tracker, which is necessary to track site searches. The URL parameters object is called `search` but seems to include all parameters, including for work pages. Unecessary parameters will be filtered out in ga, so this should not present a problem.