### PR TITLE
SFR-668 removed 'query' and 'keyword' parameters in favor of 'queries'

### DIFF
--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -61,28 +61,33 @@ class SearchForm extends React.Component {
 
   onFieldChange(event) {
     const fieldSelected = event.target.value;
-    this.setState(preState => ({
-      searchQuery: Object.assign(
-        {},
-        initialSearchQuery,
-        { showField: '', showQuery: '' },
-        { query: preState.searchQuery.showQuery ? preState.searchQuery.showQuery : preState.searchQuery.query },
-        { field: fieldSelected },
-      ),
-    }));
+    this.setState((prevState) => {
+      const advancedQuery = {
+        query: prevState.searchQuery.showQuery
+          ? prevState.searchQuery.showQuery : prevState.searchQuery.query,
+        field: fieldSelected,
+      };
+      return ({
+        searchQuery: Object.assign({}, initialSearchQuery,
+          { showField: '', showQuery: '' },
+          { queries: [].concat(advancedQuery) }),
+      });
+    });
   }
 
   onQueryChange(event) {
     const querySelected = event.target.value;
-    this.setState(preState => ({
-      searchQuery: Object.assign(
-        {},
-        initialSearchQuery,
-        { showField: '', showQuery: '' },
-        { field: preState.searchQuery.showField ? preState.searchQuery.showField : preState.searchQuery.field || 'keyword' },
-        { query: querySelected },
-      ),
-    }));
+
+    this.setState((prevState) => {
+      const advancedQuery = {
+        query: querySelected,
+        field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.field || 'keyword',
+      };
+
+      return ({
+        searchQuery: Object.assign({}, initialSearchQuery, { showField: '', showQuery: '' }, { queries: [].concat(advancedQuery) }),
+      });
+    });
     if (querySelected) {
       this.setState({ error: false, errorMsg: '' });
     }
@@ -91,7 +96,9 @@ class SearchForm extends React.Component {
   handleSubmit(event) {
     if (event && event.charCode === 13) {
       this.props.userQuery(
-        Object.assign({}, initialSearchQuery, { query: this.state.searchQuery.query, field: this.state.searchQuery.field || 'keyword' }),
+        Object.assign({}, initialSearchQuery, {
+          query: this.state.searchQuery.queries,
+        }),
       );
       this.submitSearchRequest(event);
     }
@@ -99,7 +106,7 @@ class SearchForm extends React.Component {
 
   submitSearchRequest(event) {
     event.preventDefault();
-    const query = this.state.searchQuery.query.replace(/^\s+/, '').replace(/\s+$/, '');
+    const query = this.state.searchQuery.queries[0].query.replace(/^\s+/, '').replace(/\s+$/, '');
     if (!query) {
       this.setState({ error: true, errorMsg: errorMessagesText.emptySearch });
       return;
@@ -110,8 +117,8 @@ class SearchForm extends React.Component {
   }
 
   render() {
-    const selectedQuery = this.state.searchQuery.showQuery || this.state.searchQuery.query;
-    const selectedField = this.state.searchQuery.showField || this.state.searchQuery.field;
+    const selectedQuery = this.state.searchQuery.showQuery || this.state.searchQuery.queries[0].query;
+    const selectedField = this.state.searchQuery.showField || this.state.searchQuery.queries[0].field;
 
     return (
       <div className="grid-row">

--- a/src/app/components/SearchResults/AdvancedSearchResults.jsx
+++ b/src/app/components/SearchResults/AdvancedSearchResults.jsx
@@ -41,16 +41,21 @@ const AdvancedSearchResults = ({ searchQuery, userQuery, router }) => {
           className="grid-col-10 sfr-center"
           id="advanced-search-tags"
         >
-          {searchQuery.queries.map(query => (
-            <button
-              type="button"
-              className={disableClearTag ? 'usa-button usa-button--outline tag-button' : 'usa-button usa-button--outline tag-button active'}
-              onClick={e => onClick(e, query)}
-              key={`${query.field}: ${query.query} `}
-            >
-              {`${label(query.field)}: ${query.query} `}
-            </button>
-          ))}
+          {searchQuery.queries.map((query) => {
+            if (query.field) {
+              return (
+                <button
+                  type="button"
+                  className={disableClearTag
+                    ? 'usa-button usa-button--outline tag-button' : 'usa-button usa-button--outline tag-button active'}
+                  onClick={e => onClick(e, query)}
+                  key={`${query.field}: ${query.query} `}
+                >
+                  {`${label(query.field)}: ${query.query} `}
+                </button>
+              );
+            }
+          })}
         </div>
       </div>
     );
@@ -66,7 +71,7 @@ AdvancedSearchResults.propTypes = {
 
 AdvancedSearchResults.defaultProps = {
   searchQuery: initialSearchQuery,
-  userQuery: () => {},
+  userQuery: () => { },
   router: {},
 };
 

--- a/src/app/stores/InitialState.js
+++ b/src/app/stores/InitialState.js
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 
 export const initialSearchQuery = {
-  query: '',
-  field: 'keyword',
   showQuery: '',
   showField: '',
   per_page: 10,
@@ -10,12 +8,10 @@ export const initialSearchQuery = {
   total: 0,
   filters: [],
   sort: [],
-  queries: [],
+  queries: [{ query: '', field: '' }],
 };
 
 export const searchQueryPropTypes = PropTypes.shape({
-  query: PropTypes.string,
-  field: PropTypes.string,
   showQuery: PropTypes.string,
   showField: PropTypes.string,
   per_page: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/test/unit/AdvancedSearch.test.js
+++ b/test/unit/AdvancedSearch.test.js
@@ -15,7 +15,7 @@ import initialState from '../../src/app/stores/InitialState';
 
 configure({ adapter: new Adapter() });
 
-describe('Search Container interactions', () => {
+describe('Advanced Search Container interactions', () => {
   let wrapper;
   let context;
   let childContextTypes;

--- a/test/unit/SearchContainer.test.js
+++ b/test/unit/SearchContainer.test.js
@@ -22,8 +22,8 @@ describe('Search Container interactions', () => {
 
   it('contains an initialized <SearchForm /> component', () => {
     expect(wrapper.find(SearchForm)).to.have.length(1);
-    expect(wrapper.find(SearchForm).prop('searchQuery').query).to.equal('');
-    expect(wrapper.find(SearchForm).prop('searchQuery').field).to.equal('keyword');
+    expect(wrapper.find(SearchForm).prop('searchQuery').queries[0].query).to.equal('');
+    expect(wrapper.find(SearchForm).prop('searchQuery').queries[0].field).to.equal('');
   });
   it('contains a <SearchResults /> component', () => {
     expect(wrapper.find(SearchResults)).to.have.length(1);

--- a/test/unit/SearchForm.test.js
+++ b/test/unit/SearchForm.test.js
@@ -79,19 +79,19 @@ describe('SearchForm', () => {
 
     it('should updated state values based on passed props for select', () => {
       component.find('select').simulate('change', { target: { value: 'author' } });
-      expect(component.state('searchQuery').field).to.equal('author');
+      expect(component.state('searchQuery').queries[0].field).to.equal('author');
     });
 
     it('should updated state values based on passed props for text input', () => {
       component.find('input').simulate('change', { target: { value: 'jefferson' } });
-      expect(component.state('searchQuery').query).to.equal('jefferson');
+      expect(component.state('searchQuery').queries[0].query).to.equal('jefferson');
     });
 
     it('should update state when the enter key is pressed', () => {
       component.find('input').props.value = 'jefferson';
       component.find('input').simulate('change', { target: { value: 'jackson' } });
 
-      expect(component.state('searchQuery').query).to.equal('jackson');
+      expect(component.state('searchQuery').queries[0].query).to.equal('jackson');
     });
 
     it('should update state when the button is clicked', () => {
@@ -101,7 +101,7 @@ describe('SearchForm', () => {
         .at(0)
         .simulate('change', { target: { value: 'johnson' } });
 
-      expect(component.state('searchQuery').query).to.equal('johnson');
+      expect(component.state('searchQuery').queries[0].query).to.equal('johnson');
     });
   });
 });


### PR DESCRIPTION
Updated tests as well
Not really sold on this approach, (the hardcoding of the first entry in `queries`) but it's working ok.  Happy to take another look at it now, or defer to when we have new designs!  