### PR TITLE
SFR-616 Removed hover text-decoration

### DIFF
--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -104,9 +104,6 @@ a:visited,
 a {
   color: #0071ce;
   text-decoration: none;
-  &:hover {
-    text-decoration: none;
-  }
 }
 .bold {
   font-weight: bold;


### PR DESCRIPTION
In RN the breadcrumb wasn't showing an underline on hover, because this was over-riding it.  