### PR TITLE
[771] Updates the min-height of the header embed

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -54,7 +54,7 @@
             }
             @media screen and (min-width: 1024px) {
                 #Header-Placeholder {
-                    min-height: 230px;
+                    min-height: 208px; // Updated to reflect actual height of header, SFR-771
                 }
             }
         </style>


### PR DESCRIPTION
Sets that min-height to `208px` instead of `230px`. This means we deviate from what the [React Header](https://github.com/NYPL/dgx-header-component) recommends, so I left a comment with a reference to the ticket until that documentation updates.