### PR TITLE
SFR-761 fix subject query handling

### DIFF
--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -81,7 +81,7 @@ class SearchForm extends React.Component {
     this.setState((prevState) => {
       const advancedQuery = {
         query: querySelected,
-        field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.field || 'keyword',
+        field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.queries[0].field || 'keyword',
       };
 
       return ({

--- a/src/app/components/WorkDetail/DefinitionList.jsx
+++ b/src/app/components/WorkDetail/DefinitionList.jsx
@@ -76,7 +76,7 @@ export const DefinitionList = ({ work }) => {
                   <Link
                     to={{
                       pathname: '/search',
-                      query: { query: `"${subject.subject}"`, field: 'subject' },
+                      query: { queries: `[{"query": "${subject.subject}", "field": "subject"}]` },
                     }}
                   >
                     {htmlEntities.decode(subject.subject)}


### PR DESCRIPTION
This fixes several issues around the handling of queries. The initial ticket was to investigate `500` errors stemming from making subject queries from the work detail pages. That seems to have been fixed by a different change, however investigating it revealed that non-keyword searches were not being executed properly and that the subject searches from the detail pages were not properly displaying the query "pills".

Both issues were due to their respective components using the old-style simple search query structure. Updating both of these to the new advanced search structure has fixed both issues.

The one point that could use further review is coming from the detail page I had to encode the query array as a string to get the app to parse it correctly, otherwise it rendered it as a string. I'm not sure if there was an issue with how I was passing the data, or if there is something with how that component understands the parameters passed to it, but it could use a second set of eyes.