### PR TITLE
SFR-442 Add Airtable key to production

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -169,6 +169,7 @@ if (ENV === 'production') {
         'process.env': {
           NODE_ENV: JSON.stringify('production'),
           APP_ENV: JSON.stringify(appEnv),
+          AIRTABLE_API_KEY: JSON.stringify(airtableKey),
         },
       }),
     ],


### PR DESCRIPTION
To make the Airtable key (loaded as an env var) available to the react app it must be loaded through the webpack config. This is done separately in the production and development environments and the previous commit ommitted the production code, meaning the feedback form cannot be submitted from deployed versions of the app.