### PR TITLE
SFR-593 Fix author name search

### DIFF
--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -81,12 +81,15 @@ export default class EditionCard {
 
   // Author
   static getAuthorIdentifier(author) {
-    return (author.viaf && 'viaf') || (author.lcnaf && 'lcnaf') || 'name';
+    return (author.viaf && ['viaf', 'viaf']) || (author.lcnaf && ['lcnaf', 'lcnaf']) || ['name', 'author'];
   }
 
   static getLinkToAuthorSearch(author) {
     return ({
-      queries: JSON.stringify([{ query: author[EditionCard.getAuthorIdentifier(author)], field: EditionCard.getAuthorIdentifier(author) }]),
+      queries: JSON.stringify([{
+        query: author[EditionCard.getAuthorIdentifier(author)[0]],
+        field: EditionCard.getAuthorIdentifier(author)[1],
+      }]),
       showQuery: `"${author.name}"`,
       showField: 'author',
     });

--- a/test/unit/EditionCard.test.js
+++ b/test/unit/EditionCard.test.js
@@ -599,4 +599,29 @@ describe('Edition Card', () => {
       expect(EditionCard.getReadOnlineLink(origin, testItem, eReaderUrl, referrer)).to.equal(undefined);
     });
   });
+
+  describe('get author identifier', () => {
+    let testAuthor;
+    before(() => {
+      testAuthor = {
+        name: 'Tester, Test',
+        viaf: 'n123456',
+        lcnaf: '098765x',
+      };
+    });
+
+    it('should return a tuple of viaf for viaf queries', () => {
+      expect(EditionCard.getAuthorIdentifier(testAuthor)).to.deep.equal(['viaf', 'viaf']);
+    });
+
+    it('should return lcnaf if viaf is not set', () => {
+      testAuthor.viaf = null;
+      expect(EditionCard.getAuthorIdentifier(testAuthor)).to.deep.equal(['lcnaf', 'lcnaf']);
+    });
+
+    it('should return name/author if viaf and lcnaf are not set', () => {
+      testAuthor.lcnaf = null;
+      expect(EditionCard.getAuthorIdentifier(testAuthor)).to.deep.equal(['name', 'author']);
+    });
+  });
 });


### PR DESCRIPTION
The method that constructs author searches form detail pages and search results was passing `name` as the query `field`. This should be `author` the method was returng the same field for both the `query` lookup and the `field` which works for VIAF and LCNAF queries but not for author name searches.

I've updated this to return a tuple, which is then accessed in the calling method. This fixes the issue and should "future-proof" this a bit in case we want to add future searches which may require different field and query names.

Also added are a few tests on the method to ensure that it returns the expected value.