### PR TITLE
SFR-811 Consolidated SearchForm and SearchHeader

### DIFF
--- a/src/app/components/LandingPage/LandingPage.jsx
+++ b/src/app/components/LandingPage/LandingPage.jsx
@@ -80,10 +80,7 @@ class LandingPage extends React.Component {
             </div>
             <div className="grid-row">
               <div className="sfr-center">
-                <SearchForm
-                  history={history}
-                  {...this.boundActions}
-                />
+                <SearchForm />
                 {
                 // eslint-disable-next-line no-underscore-dangle
                 FeatureFlags.store._isFeatureActive(config.booksCount.experimentName)

--- a/src/app/components/LandingPage/LandingPage.jsx
+++ b/src/app/components/LandingPage/LandingPage.jsx
@@ -9,7 +9,6 @@ import SearchForm from '../SearchForm/SearchForm';
 import Subjects from '../../../../subjectListConfig';
 import * as searchActions from '../../actions/SearchActions';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
-import { initialSearchQuery, searchQueryPropTypes } from '../../stores/InitialState';
 import { checkFeatureFlagActivated } from '../../util/Util';
 import TotalWorks from '../SearchForm/TotalWorks';
 
@@ -51,7 +50,7 @@ class LandingPage extends React.Component {
   }
 
   render() {
-    const { router, history } = this.context;
+    const { router } = this.context;
 
     return (
       <DS.Container>
@@ -105,18 +104,12 @@ class LandingPage extends React.Component {
 }
 
 LandingPage.propTypes = {
-  searchResults: PropTypes.objectOf(PropTypes.any),
-  searchQuery: searchQueryPropTypes,
   dispatch: PropTypes.func,
-  eReaderUrl: PropTypes.string,
   location: PropTypes.objectOf(PropTypes.any),
 };
 
 LandingPage.defaultProps = {
-  searchResults: {},
-  searchQuery: initialSearchQuery,
   dispatch: () => { },
-  eReaderUrl: '',
   location: {},
 };
 

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -4,153 +4,75 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import * as DS from '@nypl/design-system-react-components';
-import { getQueryString } from '../../search/query';
 import { initialSearchQuery, searchQueryPropTypes } from '../../stores/InitialState';
-import { deepEqual } from '../../util/Util';
-import { errorMessagesText } from '../../constants/labels';
+import withSearch from './WithSearch';
 
-class SearchForm extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = { ...props, ...{ error: false, errorMsg: '', isFeatureFlagsActivated: {} } };
-
-    this.onFieldChange = this.onFieldChange.bind(this);
-    this.onQueryChange = this.onQueryChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.submitSearchRequest = this.submitSearchRequest.bind(this);
-  }
-
-  componentDidMount() {
-    global.window.scrollTo(0, 0);
-  }
-
-  /**
-   * Used to update the downstream props updated by the
-   * parent component, LandingPage.
-   *
-   * @param {object} nextProps
-   */
-  componentWillReceiveProps(nextProps) {
-    if (!deepEqual(nextProps.searchQuery, this.props.searchQuery)) {
-      this.setState({ searchQuery: nextProps.searchQuery, error: false, errorMsg: '' });
-    }
-  }
-
-  onFieldChange(event) {
-    const fieldSelected = event.target.value;
-    this.setState((prevState) => {
-      const advancedQuery = {
-        query: prevState.searchQuery.showQuery
-          ? prevState.searchQuery.showQuery : prevState.searchQuery.queries[0].query,
-        field: fieldSelected,
-      };
-      return ({
-        searchQuery: Object.assign({}, initialSearchQuery,
-          { showField: '', showQuery: '' },
-          { queries: [].concat(advancedQuery) }),
-      });
-    });
-  }
-
-  onQueryChange(event) {
-    const querySelected = event.target.value;
-
-    this.setState((prevState) => {
-      const advancedQuery = {
-        query: querySelected,
-        field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.queries[0].field || 'keyword',
-      };
-
-      return ({
-        searchQuery: Object.assign({}, initialSearchQuery, { showField: '', showQuery: '' }, { queries: [].concat(advancedQuery) }),
-      });
-    });
-    if (querySelected) {
-      this.setState({ error: false, errorMsg: '' });
-    }
-  }
-
-  handleSubmit(event) {
-    if (event && event.charCode === 13) {
-      this.props.userQuery(
-        Object.assign({}, initialSearchQuery, {
-          query: this.state.searchQuery.queries,
-        }),
-      );
-    }
-  }
-
-  submitSearchRequest(event) {
-    event.preventDefault();
-    const query = this.state.searchQuery.queries[0].query.replace(/^\s+/, '').replace(/\s+$/, '');
-    if (!query) {
-      this.setState({ error: true, errorMsg: errorMessagesText.emptySearch });
-      return;
-    }
-
-    const path = `/search?${getQueryString(this.state.searchQuery)}`;
-    this.context.router.push(path);
-  }
-
-  render() {
-    const selectedQuery = this.state.searchQuery.showQuery || this.state.searchQuery.queries[0].query;
-    const selectedField = this.state.searchQuery.showField || this.state.searchQuery.queries[0].field;
-    const advancedSearchMessage = (
-      <p>
+const LandingPromo = (props) => {
+  const selectedQuery = props.currentQuery.showQuery || props.currentQuery.queries[0].query;
+  const selectedField = props.currentQuery.showField || props.currentQuery.queries[0].field;
+  const advancedSearchMessage = (
+    <p>
         Use
-        {' '}
-        <Link
-          to="advanced-search"
-          className="link"
-        >
+      {' '}
+      <Link
+        to="advanced-search"
+        className="link"
+      >
           Advanced Search
-        </Link>
-        {' '}
+      </Link>
+      {' '}
         to narrow your results.
-      </p>
-    );
+    </p>
+  );
 
-    return (
-      <div>
-        <DS.SearchPromo
-          headingText="Search the World's Research Collections"
-          titleId="tagline"
-          selectedOption={selectedField}
-          searchButtonId="searchButtonId"
-          advancedSearchMessage={advancedSearchMessage}
-          searchValue={selectedQuery}
-          hasError={this.state.error}
-          errorMessage={this.state.errorMsg}
-          searchBarId="searchBarId"
-          dropdownId="dropdownId"
-          searchInputAriaLabel="Search for keyword, author, title, or subject"
-          searchDropdownOptions={this.props.allowedFields}
-          searchSubmitHandler={this.submitSearchRequest}
-          textChangeHandler={this.onQueryChange}
-          selectChangeHandler={this.onFieldChange}
-          selectBlurHandler={this.onFieldChange}
-        />
-      </div>
-    );
-  }
-}
+  return (
+    <DS.SearchPromo
+      headingText="Search the World's Research Collections"
+      titleId="tagline"
+      selectedOption={selectedField}
+      searchButtonId="searchButtonId"
+      advancedSearchMessage={advancedSearchMessage}
+      searchValue={selectedQuery}
+      hasError={props.hasError}
+      errorMessage={props.errorMessage}
+      searchBarId="searchBarId"
+      dropdownId="dropdownId"
+      searchInputAriaLabel="Search for keyword, author, title, or subject"
+      searchDropdownOptions={props.allowedFields}
+      searchSubmitHandler={props.submitSearchRequest}
+      textChangeHandler={props.onQueryChange}
+      selectChangeHandler={props.onFieldChange}
+      selectBlurHandler={props.onFieldChange}
+    />
+  );
+};
 
-SearchForm.propTypes = {
+
+LandingPromo.propTypes = {
   allowedFields: PropTypes.arrayOf(PropTypes.any),
-  searchQuery: searchQueryPropTypes,
-  userQuery: PropTypes.func,
+  currentQuery: searchQueryPropTypes,
+  submitSearchRequest: PropTypes.func,
+  onQueryChange: PropTypes.func,
+  onFieldChange: PropTypes.func,
+  hasError: PropTypes.bool,
+  errorMessage: PropTypes.string,
 };
 
-SearchForm.defaultProps = {
+LandingPromo.defaultProps = {
   allowedFields: ['keyword', 'title', 'author', 'subject'],
-  searchQuery: initialSearchQuery,
-  userQuery: () => { },
+  currentQuery: initialSearchQuery,
+  submitSearchRequest: () => { },
+  onQueryChange: () => { },
+  onFieldChange: () => { },
+  hasError: false,
+  errorMessage: '',
 };
 
-SearchForm.contextTypes = {
+LandingPromo.contextTypes = {
   router: PropTypes.objectOf(PropTypes.any),
   history: PropTypes.objectOf(PropTypes.any),
 };
+
+const SearchForm = withSearch(LandingPromo);
 
 export default SearchForm;

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -47,7 +47,6 @@ const LandingPromo = (props) => {
   );
 };
 
-
 LandingPromo.propTypes = {
   allowedFields: PropTypes.arrayOf(PropTypes.any),
   currentQuery: searchQueryPropTypes,
@@ -68,11 +67,5 @@ LandingPromo.defaultProps = {
   errorMessage: '',
 };
 
-LandingPromo.contextTypes = {
-  router: PropTypes.objectOf(PropTypes.any),
-  history: PropTypes.objectOf(PropTypes.any),
-};
-
 const SearchForm = withSearch(LandingPromo);
-
 export default SearchForm;

--- a/src/app/components/SearchForm/SearchHeader.jsx
+++ b/src/app/components/SearchForm/SearchHeader.jsx
@@ -71,10 +71,5 @@ ResultsHeader.defaultProps = {
   errorMessage: '',
 };
 
-ResultsHeader.contextTypes = {
-  router: PropTypes.objectOf(PropTypes.any),
-  history: PropTypes.objectOf(PropTypes.any),
-};
-
 const SearchHeader = withSearch(ResultsHeader);
 export default SearchHeader;

--- a/src/app/components/SearchForm/SearchHeader.jsx
+++ b/src/app/components/SearchForm/SearchHeader.jsx
@@ -4,151 +4,77 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import * as DS from '@nypl/design-system-react-components';
-import { getQueryString } from '../../search/query';
-import { initialSearchQuery, searchQueryPropTypes } from '../../stores/InitialState';
-import { deepEqual } from '../../util/Util';
+import withSearch from './WithSearch';
 
-class SearchHeader extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = { ...props, ...{ error: false, errorMsg: '', isFeatureFlagsActivated: {} } };
-
-    this.onFieldChange = this.onFieldChange.bind(this);
-    this.onQueryChange = this.onQueryChange.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-    this.submitSearchRequest = this.submitSearchRequest.bind(this);
-  }
-
-  componentDidMount() {
-    global.window.scrollTo(0, 0);
-  }
-
-  /**
-   * Used to update the downstream props updated by the
-   * parent component, LandingPage.
-   *
-   * @param {object} nextProps
-   */
-  componentWillReceiveProps(nextProps) {
-    if (!deepEqual(nextProps.searchQuery, this.props.searchQuery)) {
-      this.setState({ searchQuery: nextProps.searchQuery });
-    }
-  }
-
-  onFieldChange(event) {
-    const fieldSelected = event.target.value;
-    this.setState((prevState) => {
-      const advancedQuery = {
-        query: prevState.searchQuery.showQuery
-          ? prevState.searchQuery.showQuery : prevState.searchQuery.queries[0].query,
-        field: fieldSelected,
-      };
-      return ({
-        searchQuery: Object.assign({}, initialSearchQuery,
-          { showField: '', showQuery: '' },
-          { queries: [].concat(advancedQuery) }),
-      });
-    });
-  }
-
-  onQueryChange(event) {
-    const querySelected = event.target.value;
-
-    this.setState((prevState) => {
-      const searchQuery = {
-        query: querySelected,
-        field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.queries[0].field || 'keyword',
-      };
-
-      return ({
-        searchQuery: Object.assign({}, initialSearchQuery, { showField: '', showQuery: '' }, { queries: [].concat(searchQuery) }),
-      });
-    });
-  }
-
-  handleSubmit(event) {
-    if (event && event.charCode === 13) {
-      this.props.userQuery(
-        Object.assign({}, initialSearchQuery, {
-          query: this.state.searchQuery.queries,
-        }),
-      );
-    }
-  }
-
-  submitSearchRequest(event) {
-    event.preventDefault();
-
-    const path = `/search?${getQueryString(this.state.searchQuery)}`;
-    this.context.router.push(path);
-  }
-
-  render() {
-    return (
-      <div>
-        <DS.HeaderWithSearch
-          searchButtonId="searchButtonId"
-          searchBarAriaLabel="Search research catalog"
-          sectionTitle={(
-            <Link
-              className="search-header__rn-section-title rn-section-title"
-              to="/"
-            >
-              <span id="research-now-title">
+const ResultsHeader = props => (
+  <DS.HeaderWithSearch
+    searchButtonId="searchButtonId"
+    searchBarAriaLabel="Search research catalog"
+    sectionTitle={(
+      <Link
+        className="search-header__rn-section-title rn-section-title"
+        to="/"
+      >
+        <span id="research-now-title">
                   Research
-                <span className="rn-section-title__emphasis">Now</span>
-              </span>
-            </Link>
+          <span className="rn-section-title__emphasis">Now</span>
+        </span>
+      </Link>
             )}
-          advancedSearchElem={(
-            <DS.UnderlineLink>
-              <Link
-                to="advanced-search"
-                className="text-baseline"
-              >
+    advancedSearchElem={(
+      <DS.UnderlineLink>
+        <Link
+          to="advanced-search"
+          className="text-baseline"
+        >
                   Advanced Search
-              </Link>
-            </DS.UnderlineLink>
+        </Link>
+      </DS.UnderlineLink>
             )}
-          searchBarId="searchBarId"
-          dropdownId="dropdownId"
-          textFieldAriaLabel="Research Now"
-          headingContent={(
-            <span>
+    searchBarId="searchBarId"
+    dropdownId="dropdownId"
+    textFieldAriaLabel="Research Now"
+    headingContent={(
+      <span>
                 Research
-              <span className="rn-section-title__emphasis">Now</span>
-            </span>
+        <span className="rn-section-title__emphasis">Now</span>
+      </span>
             )}
-          headingId="researchNow-page-title-id"
-          headingUrl="#research-now-url"
-          headingBaseClass="rn-section-title"
-          searchDropdownOptions={this.props.allowedFields}
-          searchSubmitHandler={this.submitSearchRequest}
-          textChangeHandler={this.onQueryChange}
-          selectChangeHandler={this.onFieldChange}
-          selectBlurHandler={this.onFieldChange}
-        />
-      </div>
-    );
-  }
-}
+    headingId="researchNow-page-title-id"
+    headingUrl="#research-now-url"
+    headingBaseClass="rn-section-title"
+    hasError={props.hasError}
+    errorMessage={props.errorMessage}
+    searchDropdownOptions={props.allowedFields}
+    searchSubmitHandler={props.submitSearchRequest}
+    textChangeHandler={props.onQueryChange}
+    selectChangeHandler={props.onFieldChange}
+    selectBlurHandler={props.onFieldChange}
+  />
+);
 
-SearchHeader.propTypes = {
+ResultsHeader.propTypes = {
   allowedFields: PropTypes.arrayOf(PropTypes.any),
-  searchQuery: searchQueryPropTypes,
-  userQuery: PropTypes.func,
+  submitSearchRequest: PropTypes.func,
+  onQueryChange: PropTypes.func,
+  onFieldChange: PropTypes.func,
+  hasError: PropTypes.bool,
+  errorMessage: PropTypes.string,
 };
 
-SearchHeader.defaultProps = {
+ResultsHeader.defaultProps = {
   allowedFields: ['keyword', 'title', 'author', 'subject'],
-  searchQuery: initialSearchQuery,
-  userQuery: () => { },
+  submitSearchRequest: () => { },
+  onQueryChange: () => { },
+  onFieldChange: () => { },
+  hasError: false,
+  errorMessage: '',
 };
 
-SearchHeader.contextTypes = {
+ResultsHeader.contextTypes = {
   router: PropTypes.objectOf(PropTypes.any),
   history: PropTypes.objectOf(PropTypes.any),
 };
 
+const SearchHeader = withSearch(ResultsHeader);
 export default SearchHeader;

--- a/src/app/components/SearchForm/WithSearch.jsx
+++ b/src/app/components/SearchForm/WithSearch.jsx
@@ -110,8 +110,8 @@ function withSearch(WrappedComponent) {
 
   SearchComponent.contextTypes = {
     router: PropTypes.objectOf(PropTypes.any),
-    history: PropTypes.objectOf(PropTypes.any),
   };
+
   return SearchComponent;
 }
 

--- a/src/app/components/SearchForm/WithSearch.jsx
+++ b/src/app/components/SearchForm/WithSearch.jsx
@@ -6,12 +6,17 @@ import { getQueryString } from '../../search/query';
 import { initialSearchQuery, searchQueryPropTypes } from '../../stores/InitialState';
 import { errorMessagesText } from '../../constants/labels';
 
+/** Wrapper that adds search functionality
+ It contains handling for changes in search field and search query, as well as submit handling
+
+ @param Component Component to test or React Element that needs these handlers */
+
 function withSearch(WrappedComponent) {
   class SearchComponent extends React.Component {
     constructor(props) {
       super(props);
 
-      this.state = { ...props, ...{ error: false, errorMsg: '', isFeatureFlagsActivated: {} } };
+      this.state = { error: false, errorMsg: '', ...props };
 
       this.onFieldChange = this.onFieldChange.bind(this);
       this.onQueryChange = this.onQueryChange.bind(this);
@@ -70,7 +75,7 @@ function withSearch(WrappedComponent) {
 
     submitSearchRequest(event) {
       event.preventDefault();
-      const query = this.state.searchQuery.queries[0].query.replace(/^\s+/, '').replace(/\s+$/, '');
+      const query = this.state.searchQuery.queries[0].query.trim();
       if (!query) {
         this.setState({ error: true, errorMsg: errorMessagesText.emptySearch });
         return;
@@ -86,7 +91,6 @@ function withSearch(WrappedComponent) {
           onQueryChange={this.onQueryChange}
           onFieldChange={this.onFieldChange}
           submitSearchRequest={this.submitSearchRequest}
-          context={this.context}
           currentQuery={this.state.searchQuery}
           hasError={this.state.error}
           errorMessage={this.state.errorMsg}
@@ -97,13 +101,11 @@ function withSearch(WrappedComponent) {
   }
 
   SearchComponent.propTypes = {
-    allowedFields: PropTypes.arrayOf(PropTypes.any),
     searchQuery: searchQueryPropTypes,
     userQuery: PropTypes.func,
   };
 
   SearchComponent.defaultProps = {
-    allowedFields: ['keyword', 'title', 'author', 'subject'],
     searchQuery: initialSearchQuery,
     userQuery: () => { },
   };

--- a/src/app/components/SearchForm/WithSearch.jsx
+++ b/src/app/components/SearchForm/WithSearch.jsx
@@ -1,0 +1,118 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable jsx-a11y/label-has-for */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { getQueryString } from '../../search/query';
+import { initialSearchQuery, searchQueryPropTypes } from '../../stores/InitialState';
+import { errorMessagesText } from '../../constants/labels';
+
+function withSearch(WrappedComponent) {
+  class SearchComponent extends React.Component {
+    constructor(props) {
+      super(props);
+
+      this.state = { ...props, ...{ error: false, errorMsg: '', isFeatureFlagsActivated: {} } };
+
+      this.onFieldChange = this.onFieldChange.bind(this);
+      this.onQueryChange = this.onQueryChange.bind(this);
+      this.handleSubmit = this.handleSubmit.bind(this);
+      this.submitSearchRequest = this.submitSearchRequest.bind(this);
+    }
+
+    componentDidMount() {
+      global.window.scrollTo(0, 0);
+    }
+
+    onFieldChange(event) {
+      const fieldSelected = event.target.value;
+      this.setState((prevState) => {
+        const advancedQuery = {
+          query: prevState.searchQuery.showQuery
+            ? prevState.searchQuery.showQuery : prevState.searchQuery.queries[0].query,
+          field: fieldSelected,
+        };
+        return ({
+          searchQuery: Object.assign({}, initialSearchQuery,
+            { showField: '', showQuery: '' },
+            { queries: [].concat(advancedQuery) }),
+        });
+      });
+    }
+
+    onQueryChange(event) {
+      const querySelected = event.target.value;
+
+      this.setState((prevState) => {
+        const advancedQuery = {
+          query: querySelected,
+          field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.queries[0].field || 'keyword',
+        };
+
+        return ({
+          searchQuery: Object.assign({}, initialSearchQuery, { showField: '', showQuery: querySelected },
+            { queries: [].concat(advancedQuery) }),
+        });
+      });
+      if (querySelected) {
+        this.setState({ error: false, errorMsg: '' });
+      }
+    }
+
+    handleSubmit(event) {
+      if (event && event.charCode === 13) {
+        this.props.userQuery(
+          Object.assign({}, initialSearchQuery, {
+            query: this.state.searchQuery.queries,
+          }),
+        );
+      }
+    }
+
+    submitSearchRequest(event) {
+      event.preventDefault();
+      const query = this.state.searchQuery.queries[0].query.replace(/^\s+/, '').replace(/\s+$/, '');
+      if (!query) {
+        this.setState({ error: true, errorMsg: errorMessagesText.emptySearch });
+        return;
+      }
+
+      const path = `/search?${getQueryString(this.state.searchQuery)}`;
+      this.context.router.push(path);
+    }
+
+    render() {
+      return (
+        <WrappedComponent
+          onQueryChange={this.onQueryChange}
+          onFieldChange={this.onFieldChange}
+          submitSearchRequest={this.submitSearchRequest}
+          context={this.context}
+          currentQuery={this.state.searchQuery}
+          hasError={this.state.error}
+          errorMessage={this.state.errorMsg}
+          {...this.props}
+        />
+      );
+    }
+  }
+
+  SearchComponent.propTypes = {
+    allowedFields: PropTypes.arrayOf(PropTypes.any),
+    searchQuery: searchQueryPropTypes,
+    userQuery: PropTypes.func,
+  };
+
+  SearchComponent.defaultProps = {
+    allowedFields: ['keyword', 'title', 'author', 'subject'],
+    searchQuery: initialSearchQuery,
+    userQuery: () => { },
+  };
+
+  SearchComponent.contextTypes = {
+    router: PropTypes.objectOf(PropTypes.any),
+    history: PropTypes.objectOf(PropTypes.any),
+  };
+  return SearchComponent;
+}
+
+export default withSearch;

--- a/src/app/components/SearchResults/SearchResultsPage.jsx
+++ b/src/app/components/SearchResults/SearchResultsPage.jsx
@@ -115,10 +115,7 @@ class SearchResultsPage extends React.Component {
           >
 
             <div className="sfr-center">
-              <SearchHeader
-                history={history}
-                {...this.boundActions}
-              />
+              <SearchHeader />
               {
               // eslint-disable-next-line no-underscore-dangle
               FeatureFlags.store._isFeatureActive(config.booksCount.experimentName)

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -95,10 +95,7 @@ class WorkDetail extends React.Component {
           />
           <div className="grid-row">
             <div className="sfr-center">
-              <SearchHeader
-                history={history}
-                {...this.boundActions}
-              />
+              <SearchHeader />
             </div>
           </div>
           { isValidWork

--- a/test/unit/LandingPage.test.js
+++ b/test/unit/LandingPage.test.js
@@ -21,8 +21,8 @@ describe('Landing Page render', () => {
     expect(wrapper.find('Breadcrumbs').exists()).to.equal(true);
   });
 
-  it('contains an initialized <SearchForm /> component', () => {
-    expect(wrapper.find('SearchForm').exists()).to.equal(true);
+  it('contains an initialized <LandingPromo /> component', () => {
+    expect(wrapper.find('LandingPromo').exists()).to.equal(true);
   });
   it('contains an <h1>', () => {
     expect(wrapper.find('h1')).to.have.length(1);

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -49,16 +49,14 @@ describe('Search Results Page', () => {
     it('contains a <Breadcrumbs /> component', () => {
       expect(wrapper.find('Breadcrumbs').exists()).to.equal(true);
     });
-
-    it('contains an initialized <SearchComponent /> component', () => {
-      expect(wrapper.find('SearchComponent').exists()).to.equal(true);
+    it('contains a <ResultsHeader /> component', () => {
+      expect(wrapper.find('ResultsHeader').exists()).to.equal(true);
     });
-
     it('contains an <h1>', () => {
       expect(wrapper.find('h1')).to.have.length(1);
     });
-    it('contains a <ResultsHeader /> component', () => {
-      expect(wrapper.find('ResultsHeader').exists()).to.equal(true);
+    it('contains a <SearchResults /> component', () => {
+      expect(wrapper.find('SearchResults').exists()).to.equal(true);
     });
   });
 });

--- a/test/unit/SearchResultsPage.test.js
+++ b/test/unit/SearchResultsPage.test.js
@@ -50,15 +50,15 @@ describe('Search Results Page', () => {
       expect(wrapper.find('Breadcrumbs').exists()).to.equal(true);
     });
 
-    it('contains an initialized <SearchHeader /> component', () => {
-      expect(wrapper.find('SearchHeader').exists()).to.equal(true);
+    it('contains an initialized <SearchComponent /> component', () => {
+      expect(wrapper.find('SearchComponent').exists()).to.equal(true);
     });
 
     it('contains an <h1>', () => {
       expect(wrapper.find('h1')).to.have.length(1);
     });
-    it('contains a <SearchResults /> component', () => {
-      expect(wrapper.find('SearchHeader').exists()).to.equal(true);
+    it('contains a <ResultsHeader /> component', () => {
+      expect(wrapper.find('ResultsHeader').exists()).to.equal(true);
     });
   });
 });

--- a/test/unit/WorkDetail.test.js
+++ b/test/unit/WorkDetail.test.js
@@ -29,8 +29,8 @@ describe('Work Detail Page Test', () => {
       expect(container.find('Breadcrumbs').exists()).to.equal(true);
     });
 
-    it('should show searchHeader', () => {
-      expect(container.find('SearchHeader').exists()).to.equal(true);
+    it('should show ResultsHeader', () => {
+      expect(container.find('ResultsHeader').exists()).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
For info on what HOCs are => https://reactjs.org/docs/higher-order-components.html
This is really quite a textbook case to use HOCs, all the lifecycle methods for the two components are the same, but it needs to render different things.  In the past, this could have been done via
```
render() {
return shouldBeSearchPromo ? <SearchPromo /> : <SearchHeader /> 
}
```

(and we did something that was conceptually similar)
but this is way saner

The thing I didn't do was abstract out the unit tests - since they're all on lifecycle and event stuff, it would be a lot of mocking and simulating that I haven't yet figured out how to do without going slightly mad 