### PR TITLE
SFR-89 Added underline to request digitization link

### DIFF
--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Link } from 'react-router';
 import { Html5Entities } from 'html-entities';
 import * as DS from '@nypl/design-system-react-components';
+import { UnderlineLink } from '@nypl/design-system-react-components';
 import {
   MAX_TITLE_LENGTH, MAX_PUBLISHER_NAME_LENGTH, MAX_SUBTITILE_LENGTH, PLACEHOLDER_COVER_LINK,
 } from '../../constants/editioncard';
 import { formatUrl } from '../../util/Util';
-import { UnderlineLink } from '@nypl/design-system-react-components';
 
 
 const htmlEntities = new Html5Entities();
@@ -203,13 +203,12 @@ export default class EditionCard {
       return (
         <span>
           Not Yet Available
-        {" "}
+          {' '}
           {showRequestButton}
         </span>
       );
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   static getEditionData(edition, origin, eReaderUrl, referrer, showRequestButton) {

--- a/src/app/components/SearchResults/ResultsList.jsx
+++ b/src/app/components/SearchResults/ResultsList.jsx
@@ -71,7 +71,7 @@ class ResultsList extends React.Component {
         <a
           role="link"
           tabIndex="0"
-          className="link"
+          className="link request-digital-link"
           onKeyDown={(event) => { if (event.keyCode === 13) { this.openForm(result, result.editions[0]); } }}
           onClick={() => this.openForm(result, result.editions[0])}
         >

--- a/src/app/components/WorkDetail/WorkDetail.jsx
+++ b/src/app/components/WorkDetail/WorkDetail.jsx
@@ -103,7 +103,7 @@ class WorkDetail extends React.Component {
       <a
         role="link"
         tabIndex="0"
-        className="link"
+        className="link request-digital-link"
         onKeyDown={(event) => { if (event.keyCode === 13) { this.openForm(edition); } }}
         onClick={() => this.openForm(edition)}
       >

--- a/src/client/styles/components/RequestDigitization.scss
+++ b/src/client/styles/components/RequestDigitization.scss
@@ -1,3 +1,7 @@
+.request-digital-link {
+  text-decoration: underline;
+}
+
 .request-digital {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-89)

### This PR does the following:
- Adds an underline class to the request digitization link
- This class is usually added by a default User Agent stylesheet, but it isn't getting applied here because the `<a>` has no `href`
- This style will be removed when we figure out a way to display the "Request Digitization" not-quite-button-because-it-looks-like-a-link. 

### Testing requirements & instructions: 
-  
