### PR TITLE
[SFR-866] Landing Header Hotfix

### DIFF
--- a/src/client/styles/main.scss
+++ b/src/client/styles/main.scss
@@ -200,3 +200,14 @@ select {
 h2#featured-edition {
   margin-top: 0.75em;
 }
+
+// Hotfixes that should be removed with DS hero work
+// Fixes issue where background color of header doesn't
+// extend to edges of screen
+.header-with-image-right {
+  box-shadow: inset 0 3.25rem #377f8b;
+}
+
+.header-with-image-right__content {
+  max-width: unset;
+}


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-866)

### This PR does the following:
- Fixes vertical alignment for type on homepage within header area
- Extends the background color on the header to the sides of the page

Current:
<img width="904" alt="Screen Shot 2020-03-19 at 12 29 53 PM" src="https://user-images.githubusercontent.com/1720093/77090324-5b611780-69dd-11ea-8bc4-83f7bd05ea03.png">

After hotfix:
<img width="787" alt="Screen Shot 2020-03-19 at 12 27 48 PM" src="https://user-images.githubusercontent.com/1720093/77090340-60be6200-69dd-11ea-9cc0-e6ab8767323c.png">

Please note this should be ripped out after a release for the new hero gets cut for the DS.