### PR TITLE
SFR-843 Separated out Query and ShowQuery 

### DIFF
--- a/src/app/components/AdvancedSearch/AdvancedSearch.jsx
+++ b/src/app/components/AdvancedSearch/AdvancedSearch.jsx
@@ -19,7 +19,7 @@ import FilterYears from '../SearchResults/FilterYears';
 import { searchFields } from '../../constants/fields';
 
 
-const initialState = {
+export const initialState = {
   error: false,
   errorMsg: '',
   languages: [],
@@ -302,7 +302,6 @@ class AdvancedSearch extends React.Component {
     const languagesSelected = this.state.languages.filter(language => this.state.filters.language.indexOf(language.value) > -1);
     const getQueryValue = key => this.state.showQueries[key];
     const getFilterValue = (filter, key) => this.state.filters[filter] && this.state.filters[filter][key];
-
     return (
       <main
         id="mainContent"

--- a/src/app/components/AdvancedSearch/AdvancedSearch.jsx
+++ b/src/app/components/AdvancedSearch/AdvancedSearch.jsx
@@ -16,6 +16,7 @@ import TextInput from '../Form/TextInput';
 import Checkbox from '../Form/Checkbox';
 import { inputTerms, formatTypes, errorMessagesText } from '../../constants/labels';
 import FilterYears from '../SearchResults/FilterYears';
+import { searchFields } from '../../constants/fields';
 
 
 const initialState = {
@@ -27,6 +28,7 @@ const initialState = {
     title: '',
     author: '',
     subject: '',
+    viaf: '',
   },
   filters: {
     format: {
@@ -39,6 +41,12 @@ const initialState = {
       start: '',
       end: '',
     },
+  },
+  showQueries: {
+    keyword: '',
+    title: '',
+    author: '',
+    subject: '',
   },
 };
 // style for the languages dropdown
@@ -106,14 +114,18 @@ class AdvancedSearch extends React.Component {
     const value = target.type === 'checkbox' ? target.checked : target.value;
     const name = target.name;
     this.setState((prevState) => {
+      const showQueries = prevState.showQueries;
       const queries = prevState.queries;
       queries[name] = value;
+      showQueries[name] = value;
       if (name === 'author') {
         // Changing author should clear viaf and lcnaf
         queries.viaf = '';
         queries.lcnaf = '';
       }
-      return { queries, error: false, errorMsg: '' };
+      return {
+        queries, showQueries, error: false, errorMsg: '',
+      };
     });
   }
 
@@ -176,6 +188,13 @@ class AdvancedSearch extends React.Component {
       })
       .filter(q => !!q.query);
 
+    const showQueries = Object.keys(this.state.showQueries)
+      .map((q) => {
+        const query = this.state.showQueries[q] && this.state.showQueries[q].replace(/^\s+/, '').replace(/\s+$/, '');
+        return { field: q, query };
+      })
+      .filter(q => !!q.query);
+
     const filters = [];
     if (this.state.filters.language && this.state.filters.language.length > 0) {
       Object.keys(this.state.filters.language).forEach((language) => {
@@ -202,19 +221,16 @@ class AdvancedSearch extends React.Component {
       });
     }
 
-    if ((!queries || queries.length < 1) && (!filters || filters.length < 1)) {
+    if ((!queries || queries.length < 1) && (!filters || filters.length < 1) && (!showQueries || showQueries.length < 1)) {
       return null;
     }
-    return Object.assign({}, { page: '0', per_page: '10', sort: [] }, { queries, filters });
+    return Object.assign({}, { page: '0', per_page: '10', sort: [] }, { queries, filters, showQueries });
   }
 
   parseQueryToState(searchQuery) {
-    const state = { queries: {}, filters: {} };
+    const state = { queries: {}, showQueries: {}, filters: {} };
     if (!searchQuery) {
       return;
-    }
-    if (searchQuery.showField && searchQuery.showQuery) {
-      state.queries[searchQuery.showField] = searchQuery.showQuery;
     }
 
     if (searchQuery.queries) {
@@ -225,13 +241,13 @@ class AdvancedSearch extends React.Component {
         }
       });
     }
-    // If viaf or lcnaf is set, but author is not set, they were publisher searches
-    // Since we don't give users a way to clear this, we should
-    // pre-emptively clear it.
-    if (!state.queries.author) {
-      state.queries.viaf = '';
-      state.queries.lcnaf = '';
-    }
+
+    const displaySearchQueries = searchQuery.queries.filter(query => searchFields.includes(query.field));
+    const displayQueries = searchQuery.showQueries.concat(displaySearchQueries);
+
+    displayQueries.forEach((query) => {
+      state.showQueries[query.field] = query.query;
+    });
 
     if (searchQuery.filters) {
       searchQuery.filters.forEach((q) => {
@@ -253,7 +269,8 @@ class AdvancedSearch extends React.Component {
     this.setState((prevState) => {
       const filters = { ...prevState.filters, ...state.filters };
       const queries = { ...prevState.queries, ...state.queries };
-      return { filters, queries };
+      const showQueries = { ...prevState.showQueries, ...state.showQueries };
+      return { filters, queries, showQueries };
     });
   }
 
@@ -283,7 +300,7 @@ class AdvancedSearch extends React.Component {
     const { searchQuery, location } = this.props;
     const { router } = this.context;
     const languagesSelected = this.state.languages.filter(language => this.state.filters.language.indexOf(language.value) > -1);
-    const getQueryValue = key => this.state.queries[key];
+    const getQueryValue = key => this.state.showQueries[key];
     const getFilterValue = (filter, key) => this.state.filters[filter] && this.state.filters[filter][key];
 
     return (

--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -91,8 +91,7 @@ export default class EditionCard {
         query: author[EditionCard.getAuthorIdentifier(author)[0]],
         field: EditionCard.getAuthorIdentifier(author)[1],
       }]),
-      showQuery: `"${author.name}"`,
-      showField: 'author',
+      showQueries: JSON.stringify([{ query: author.name, field: 'author' }]),
     });
   }
 

--- a/src/app/components/SearchForm/SearchForm.jsx
+++ b/src/app/components/SearchForm/SearchForm.jsx
@@ -6,10 +6,11 @@ import { Link } from 'react-router';
 import * as DS from '@nypl/design-system-react-components';
 import { initialSearchQuery, searchQueryPropTypes } from '../../stores/InitialState';
 import withSearch from './WithSearch';
+import { searchFields } from '../../constants/fields';
 
 const LandingPromo = (props) => {
-  const selectedQuery = props.currentQuery.showQuery || props.currentQuery.queries[0].query;
-  const selectedField = props.currentQuery.showField || props.currentQuery.queries[0].field;
+  const selectedQuery = props.currentQuery.queries[0].query;
+  const selectedField = props.currentQuery.queries[0].field;
   const advancedSearchMessage = (
     <p>
         Use
@@ -58,7 +59,7 @@ LandingPromo.propTypes = {
 };
 
 LandingPromo.defaultProps = {
-  allowedFields: ['keyword', 'title', 'author', 'subject'],
+  allowedFields: searchFields,
   currentQuery: initialSearchQuery,
   submitSearchRequest: () => { },
   onQueryChange: () => { },

--- a/src/app/components/SearchForm/SearchHeader.jsx
+++ b/src/app/components/SearchForm/SearchHeader.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import * as DS from '@nypl/design-system-react-components';
 import withSearch from './WithSearch';
+import { searchFields } from '../../constants/fields';
 
 const ResultsHeader = props => (
   <DS.HeaderWithSearch
@@ -65,7 +66,7 @@ ResultsHeader.propTypes = {
 };
 
 ResultsHeader.defaultProps = {
-  allowedFields: ['keyword', 'title', 'author', 'subject'],
+  allowedFields: searchFields,
   submitSearchRequest: () => { },
   onQueryChange: () => { },
   onFieldChange: () => { },

--- a/src/app/components/SearchForm/WithSearch.jsx
+++ b/src/app/components/SearchForm/WithSearch.jsx
@@ -37,7 +37,7 @@ function withSearch(WrappedComponent) {
         };
         return ({
           searchQuery: Object.assign({}, initialSearchQuery,
-            { showField: '', showQuery: '' },
+            { showQueries: [].concat(advancedQuery) },
             { queries: [].concat(advancedQuery) }),
         });
       });
@@ -49,11 +49,12 @@ function withSearch(WrappedComponent) {
       this.setState((prevState) => {
         const advancedQuery = {
           query: querySelected,
-          field: prevState.searchQuery.showField ? prevState.searchQuery.showField : prevState.searchQuery.queries[0].field || 'keyword',
+          field: prevState.searchQuery.showQueries[0] ? prevState.searchQuery.showQueries[0].field : prevState.searchQuery.queries[0].field || 'keyword',
         };
 
         return ({
-          searchQuery: Object.assign({}, initialSearchQuery, { showField: '', showQuery: querySelected },
+          searchQuery: Object.assign({}, initialSearchQuery,
+            { showQueries: [].concat(advancedQuery) },
             { queries: [].concat(advancedQuery) }),
         });
       });

--- a/src/app/components/SearchResults/SearchResultsPage.jsx
+++ b/src/app/components/SearchResults/SearchResultsPage.jsx
@@ -13,6 +13,7 @@ import TotalWorks from '../SearchForm/TotalWorks';
 
 import featureFlagConfig from '../../../../featureFlagConfig';
 import config from '../../../../appConfig';
+import { searchFields } from '../../constants/fields';
 import SearchHeader from '../SearchForm/SearchHeader';
 import SearchResults from './SearchResults';
 
@@ -38,6 +39,9 @@ export const loadSearch = (props, context) => {
     }
     if (query && query.queries) {
       newQuery = Object.assign({}, newQuery, { queries: JSON.parse(query.queries) });
+    }
+    if (query && query.showQueries) {
+      newQuery = Object.assign({}, newQuery, { showQueries: JSON.parse(query.showQueries) });
     }
     if (searchQuery && !deepEqual(newQuery, searchQuery)) {
       dispatch(searchActions.userQuery(newQuery));
@@ -91,13 +95,10 @@ class SearchResultsPage extends React.Component {
   }
 
   getDisplayItemsHeading() {
-    const showField = this.props.searchQuery.showField;
-    const showQuery = this.props.searchQuery.showQuery;
-    if (showField && showQuery) {
-      return `${showField}: ${showQuery}`;
-    }
-    const queries = this.props.searchQuery.queries.map((query, index) => {
-      const joiner = index < this.props.searchQuery.queries.length - 1 ? ' and ' : '';
+    const queriesToShow = this.props.searchQuery.showQueries
+      .filter(query => searchFields.includes(query.field));
+    const queries = queriesToShow.map((query, index) => {
+      const joiner = index < queriesToShow.length - 1 ? ' and ' : '';
       return `${query.field}: ${query.query}${joiner}`;
     });
     return queries.join('');

--- a/src/app/constants/fields.js
+++ b/src/app/constants/fields.js
@@ -1,4 +1,4 @@
-const fields = {
+export const fields = {
   author: 'author',
   title: 'title',
   subject: 'subject',
@@ -6,4 +6,4 @@ const fields = {
   lcnaf: 'lcnaf',
 };
 
-export default fields;
+export const searchFields = ['keyword', 'title', 'author', 'subject'];

--- a/src/app/stores/InitialState.js
+++ b/src/app/stores/InitialState.js
@@ -1,24 +1,22 @@
 import PropTypes from 'prop-types';
 
 export const initialSearchQuery = {
-  showQuery: '',
-  showField: 'keyword',
   per_page: 10,
   page: 0,
   total: 0,
   filters: [],
   sort: [],
   queries: [{ query: '', field: '' }],
+  showQueries: [],
 };
 
 export const searchQueryPropTypes = PropTypes.shape({
-  showQuery: PropTypes.string,
-  showField: PropTypes.string,
   per_page: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   page: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   total: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   filters: PropTypes.arrayOf(PropTypes.any),
   queries: PropTypes.arrayOf(PropTypes.any),
+  showQueries: PropTypes.arrayOf(PropTypes.any),
   sort: PropTypes.arrayOf(PropTypes.any),
 });
 

--- a/test/unit/AdvancedSearch.test.js
+++ b/test/unit/AdvancedSearch.test.js
@@ -9,7 +9,7 @@ import Select from 'react-select';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/core';
 import { mockRouterContext } from '../helpers/routing';
-import AdvancedSearch from '../../src/app/components/AdvancedSearch/AdvancedSearch';
+import AdvancedSearch, { initialState as initialAdvancedState } from '../../src/app/components/AdvancedSearch/AdvancedSearch';
 import TextInput from '../../src/app/components/Form/TextInput';
 import Checkbox from '../../src/app/components/Form/Checkbox';
 import configureStore from '../../src/app/stores/configureStore';
@@ -32,7 +32,7 @@ describe('Advanced Search Container interactions', () => {
   let childContextTypes;
   let push;
 
-  before(() => {
+  beforeEach(() => {
     const store = configureStore(initialState);
     push = stub();
     context = mockRouterContext(push);
@@ -41,7 +41,7 @@ describe('Advanced Search Container interactions', () => {
     wrapper = mount(withCacheProvider(<AdvancedSearch store={store} />), { context, childContextTypes });
   });
 
-  after(() => {
+  afterEach(() => {
     wrapper.unmount();
   });
 
@@ -92,6 +92,52 @@ describe('Advanced Search Container interactions', () => {
       .simulate('change', { target: { key: 'keyword', name: 'keyword', value: 'london' } });
     wrapper.find('.usa-button').find({ value: 'Search' }).simulate('click');
     expect(wrapper.find('.usa-alert__text').exists()).to.equal(false);
+  });
+});
+
+describe('Advanced Search Prepopulates based on query', () => {
+  let wrapper;
+  let context;
+  let childContextTypes;
+  let push;
+
+  before(() => {
+    const store = configureStore(initialState);
+    push = stub();
+    context = mockRouterContext(push);
+    childContextTypes = mockRouterContext(push);
+
+    wrapper = mount(withCacheProvider(<AdvancedSearch store={store} />), { context, childContextTypes });
+  });
+
+  after(() => {
+    wrapper.find('AdvancedSearch').setState(initialAdvancedState);
+    wrapper.unmount();
+  });
+
+  it('prepopulates field when passed showQuery without query', () => {
+    wrapper.find('AdvancedSearch').setState({ showQueries: { author: 'cat' } });
+    expect(wrapper.find('.usa-input').find({ name: 'author' }).prop('value')).to.equal('cat');
+  });
+});
+
+describe('Date Filter Validation', () => {
+  let wrapper;
+  let context;
+  let childContextTypes;
+  let push;
+
+  beforeEach(() => {
+    const store = configureStore(initialState);
+    push = stub();
+    context = mockRouterContext(push);
+    childContextTypes = mockRouterContext(push);
+
+    wrapper = mount(withCacheProvider(<AdvancedSearch store={store} />), { context, childContextTypes });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
   });
 
   it('no error on start date with no end date', () => {

--- a/test/unit/WithSearch.test.js
+++ b/test/unit/WithSearch.test.js
@@ -50,8 +50,7 @@ const testQuery = {
   page: '0',
   per_page: '10',
   queries: [{ field: 'keyword', query: 'cat' }],
-  showField: '',
-  showQuery: '',
+  showQueries: [{ field: 'keyword', query: 'cat' }],
   sort: '[]',
   total: '0',
 };
@@ -73,7 +72,8 @@ describe('With Search Component', () => {
   });
   it('should change state on queryChange', () => {
     wrapper.find('input').simulate('change', { target: { value: 'candles' } });
-    expect(wrapper.state().searchQuery.showQuery).to.equal('candles');
+    expect(wrapper.state().searchQuery.queries[0]).to.eql({ query: 'candles', field: 'keyword' });
+    expect(wrapper.state().searchQuery.showQueries[0]).to.eql({ query: 'candles', field: 'keyword' });
   });
 
   it('should change state on FieldChange', () => {


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-843)

### This PR does the following:
- Query and ShowQuery were inferring values off of each other.  
- This PR separates them so that they are always set differently.  This allows us to handle queries that are used in search (eg: viaf) that are different from what is shown to the user,  (eg: if searching by viaf, should override author search, but author search should be used when no viaf is available) 

### Testing requirements & instructions: 
-  
