### PR TITLE
HOTFIX Remove HTTP protocol coercion

### DIFF
--- a/appConfig.js
+++ b/appConfig.js
@@ -11,9 +11,11 @@ export default {
     production: 'https://digital-research-books-reader.nypl.org',
   },
   api: {
+    local: 'https://dev-platform.nypl.org/api/v0.1/research-now/v3',
     development: 'https://dev-platform.nypl.org/api/v0.1/research-now/v3',
     production: 'https://digital-research-books-api.nypl.org/v3/sfr',
     searchPath: {
+      local: '/search-api',
       development: '/search-api',
       production: '/search',
     },
@@ -29,6 +31,7 @@ export default {
     experimentName: 'RequestDigital',
   },
   analytics: {
+    local: '',
     development: 'UA-1420324-149',
     production: 'UA-1420324-149',
   },

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "rnw-front-end-development",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "ResearchNow front-end application for NYPL's newest search & retrieval platform.",
   "author": "NYPL Digital",
   "main": "index.js",
   "scripts": {
     "start": "node index",
     "eb-start": "npm run dist && node index",
-    "dev-start": "APP_ENV=development npm start",
+    "local-start": "APP_ENV=local NODE_ENV=development npm start",
+    "dev-start": "APP_ENV=development NODE_ENV=development npm start",
     "prod-start": "APP_ENV=development NODE_ENV=production npm start",
     "dist": "NODE_ENV=production ./node_modules/.bin/webpack --config webpack.config.babel.js",
     "rebuild-modules": "rm -rf node_modules && npm install",

--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -170,7 +170,7 @@ export default class EditionCard {
   static generateStreamedReaderUrl(url, eReaderUrl, referrer) {
     const base64BookUrl = Buffer.from(formatUrl(url)).toString('base64');
     const encodedBookUrl = encodeURIComponent(`${base64BookUrl}`);
-    console.log(eReaderUrl)
+
     let combined = `${eReaderUrl}/readerNYPL/?url=${eReaderUrl}/pub/${encodedBookUrl}/manifest.json`;
     if (referrer) {
       combined += `#${referrer}`;

--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -117,7 +117,7 @@ export default class EditionCard {
     if (!previewEdition.covers || !previewEdition.covers.length) return PLACEHOLDER_COVER_LINK;
 
     const firstLocalCover = previewEdition.covers.find(cover => cover.flags.temporary === false);
-    return firstLocalCover ? formatUrl(firstLocalCover.url, process.env.APP_ENV) : PLACEHOLDER_COVER_LINK;
+    return firstLocalCover ? formatUrl(firstLocalCover.url) : PLACEHOLDER_COVER_LINK;
   }
 
   // Publisher Location and name
@@ -168,9 +168,9 @@ export default class EditionCard {
   // This is specific to and backwards-engineered from the webpub-viewer URLs.
   // and should be changed when webpub-viewer is able to generate more reasonable URLs.
   static generateStreamedReaderUrl(url, eReaderUrl, referrer) {
-    const base64BookUrl = Buffer.from(formatUrl(url, process.env.APP_ENV)).toString('base64');
+    const base64BookUrl = Buffer.from(formatUrl(url)).toString('base64');
     const encodedBookUrl = encodeURIComponent(`${base64BookUrl}`);
-
+    console.log(eReaderUrl)
     let combined = `${eReaderUrl}/readerNYPL/?url=${eReaderUrl}/pub/${encodedBookUrl}/manifest.json`;
     if (referrer) {
       combined += `#${referrer}`;
@@ -197,7 +197,7 @@ export default class EditionCard {
     return (
       <Link
         className="edition-card__card-info-link"
-        to={{ pathname: '/read-online', search: `?url=${formatUrl(selectedLink.url, process.env.APP_ENV)}`, state: { work } }}
+        to={{ pathname: '/read-online', search: `?url=${formatUrl(selectedLink.url)}`, state: { work } }}
       >
         Read Online
       </Link>
@@ -207,7 +207,7 @@ export default class EditionCard {
   static getDownloadLink(editionItem) {
     if (!editionItem || !editionItem.links) return undefined;
     const selectedLink = editionItem.links.find(link => link.download);
-    return selectedLink && selectedLink.url ? formatUrl(selectedLink.url, process.env.APP_ENV) : undefined;
+    return selectedLink && selectedLink.url ? formatUrl(selectedLink.url) : undefined;
   }
 
   static getNoLinkElement(showRequestButton) {

--- a/src/app/components/Viewer/EBookViewer.jsx
+++ b/src/app/components/Viewer/EBookViewer.jsx
@@ -55,7 +55,7 @@ class EBookViewer extends React.Component {
       && (
       <iframe
         allowFullScreen
-        src={`${formatUrl(bookUrl, process.env.APP_ENV)}`}
+        src={`${formatUrl(bookUrl)}`}
         title="Ebook Frame"
       />
       ) }

--- a/src/app/util/Util.jsx
+++ b/src/app/util/Util.jsx
@@ -5,20 +5,8 @@ import FeatureFlags from 'dgx-feature-flags';
 const entriesPolyFill = obj => Object.keys(obj).map(key => [key, obj[key]]);
 if (!Object.entries) Object.entries = entriesPolyFill;
 
-// Given a link, return the link with 'http' if on development, 'https' if on production.
-
-export const formatUrl = (link, env) => {
-  const prefix = env === 'development' ? 'http://' : 'https://';
-  if (env === 'development') {
-    // If passed https, change to http
-    if (link.startsWith('https://')) {
-      return `http://${link.substr(8)}`;
-    }
-  } else if (env !== 'production') {
-    console.warn(`Environment should be either "development" or "production" but got ${env}`);
-  }
-  return link.startsWith('http') ? link : prefix + link;
-};
+// Given a link ensure that it has an attached protocol and add https if none is found
+export const formatUrl = link => (link.startsWith('http') ? link : `https://${link}`);
 
 export const getNumberOfPages = (totalItems, perPage) => Math.floor((Number(totalItems || 0) - 1) / Number(perPage || 10)) + 1 || 1;
 

--- a/test/unit/Util.test.js
+++ b/test/unit/Util.test.js
@@ -12,17 +12,14 @@ import { formatUrl, joinArrayOfElements, getNumberOfPages } from '../../src/app/
 configure({ adapter: new Adapter() });
 
 describe('formatUrl', () => {
-  it('prefixes a url with http in development', () => {
-    expect(formatUrl('www.nypl.org', 'development')).to.equal('http://www.nypl.org');
+  it('prefixes a url with https in all environments', () => {
+    expect(formatUrl('www.nypl.org')).to.equal('https://www.nypl.org');
   });
-  it('prefixes a url with https in production', () => {
-    expect(formatUrl('www.nypl.org', 'production')).to.equal('https://www.nypl.org');
-  });
-  it('changes https to http in development', () => {
-    expect(formatUrl('https://nypl.org', 'development')).to.equal('http://nypl.org');
-  });
-  it('passes through http in production', () => {
+  it('passes through http', () => {
     expect(formatUrl('http://nypl.org', 'production')).to.equal('http://nypl.org');
+  });
+  it('passes through https', () => {
+    expect(formatUrl('https://nypl.org', 'production')).to.equal('https://nypl.org');
   });
 });
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -89,7 +89,7 @@ if (ENV === 'development') {
       new webpack.HotModuleReplacementPlugin(),
       new webpack.DefinePlugin({
         'process.env': {
-          APP_ENV: JSON.stringify('local'),
+          APP_ENV: JSON.stringify(appEnv),
           AIRTABLE_API_KEY: JSON.stringify(airtableKey),
         },
       }),

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -89,7 +89,7 @@ if (ENV === 'development') {
       new webpack.HotModuleReplacementPlugin(),
       new webpack.DefinePlugin({
         'process.env': {
-          APP_ENV: JSON.stringify('development'),
+          APP_ENV: JSON.stringify('local'),
           AIRTABLE_API_KEY: JSON.stringify(airtableKey),
         },
       }),


### PR DESCRIPTION
HOTFIX - No JIRA ticket

### This PR does the following:
The `formatUrl` shim was put in to force URLs to use a certain protocol for environmental reasons (generally being forced to https). Due to updates in the environments this is no longer necessary.

The method is still in place but now simply adds a protocol to any URL that is missing one (this is necessary, for example, with covers). This should allow for certain components, such as the reader app, to work as intended in all environments.

This also adds a new environment: `local`. This is similar to `development` but has some specific settings to allow for easier local development. It can be started by using `npm run local-start` and requires that a local instance of the webpub-reader app be running at `localhost:4444`

### Testing requirements & instructions: 
- Run a local instance of the app with `npm run local-start`
- Verify that all resources load properly with a focus on covers, the ePub reader and other 3rd party readers embedded via iFrame 
