### PR TITLE
SFR-885 Add GA tracking events for Read Online and Download buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## [0.8.5]
+### Added
+- Google Analytics Events for Read Online and Download links
+
 ## [0.8.4]
 ### Added
 - Production deployment step to TravisCI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rnw-front-end-development",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "ResearchNow front-end application for NYPL's newest search & retrieval platform.",
   "author": "NYPL Digital",
   "main": "index.js",

--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import { gaUtils } from 'dgx-react-ga';
 import { Html5Entities } from 'html-entities';
 import * as DS from '@nypl/design-system-react-components';
 import {
@@ -189,6 +190,7 @@ export default class EditionCard {
         <Link
           className="edition-card__card-info-link"
           to={{ pathname: '/read-online', search: `?url=${encodeURI(encodedUrl)}`, state: { work } }}
+          onClick={() => gaUtils.trackGeneralEvent('Read Online', editionItem.source, work.title, '')}
         >
           Read Online
         </Link>
@@ -198,6 +200,7 @@ export default class EditionCard {
       <Link
         className="edition-card__card-info-link"
         to={{ pathname: '/read-online', search: `?url=${formatUrl(selectedLink.url, process.env.APP_ENV)}`, state: { work } }}
+        onClick={() => gaUtils.trackGeneralEvent('Read Online', editionItem.source, work.title, '')}
       >
         Read Online
       </Link>
@@ -236,7 +239,7 @@ export default class EditionCard {
       language: EditionCard.getLanguageDisplayText(edition),
       license: <DS.UnderlineLink><Link to="/license">{ EditionCard.getLicense(editionItem) }</Link></DS.UnderlineLink>,
       readOnlineLink: EditionCard.getReadOnlineLink(work, editionItem, eReaderUrl, referrer),
-      downloadLink: EditionCard.getDownloadLink(editionItem),
+      downloadLink: EditionCard.getDownloadLink(work, editionItem),
       noLinkElement: EditionCard.getNoLinkElement(showRequestButton),
     };
   }

--- a/src/app/components/Card/EditionCard.jsx
+++ b/src/app/components/Card/EditionCard.jsx
@@ -207,10 +207,23 @@ export default class EditionCard {
     );
   }
 
-  static getDownloadLink(editionItem) {
+  static getDownloadLink(work, editionItem) {
     if (!editionItem || !editionItem.links) return undefined;
     const selectedLink = editionItem.links.find(link => link.download);
-    return selectedLink && selectedLink.url ? formatUrl(selectedLink.url, process.env.APP_ENV) : undefined;
+
+    if (selectedLink && selectedLink.url) {
+      return (
+        <a
+          className="edition-card__card-info-link"
+          href={`${formatUrl(selectedLink.url, process.env.APP_ENV)}`}
+          onClick={() => gaUtils.trackGeneralEvent('Download', editionItem.source, work.title, '')}
+        >
+          Download
+        </a>
+      );
+    }
+
+    return undefined;
   }
 
   static getNoLinkElement(showRequestButton) {

--- a/test/unit/EditionCard.test.js
+++ b/test/unit/EditionCard.test.js
@@ -475,7 +475,8 @@ describe('Edition Card', () => {
           images: true,
           ebook: true,
         }];
-      expect(EditionCard.getDownloadLink(testItem)).to.equal('https://download-url');
+      const downloadComponent = EditionCard.getDownloadLink(work, testItem);
+      expect(downloadComponent.props.href).to.equal('https://download-url');
     });
     it('should return the first link if multiple are downloadable', () => {
       testItem.links = [
@@ -499,7 +500,8 @@ describe('Edition Card', () => {
           images: true,
           ebook: true,
         }];
-      expect(EditionCard.getDownloadLink(testItem)).to.equal('https://download-url-1');
+      const downloadComponent = EditionCard.getDownloadLink(work, testItem);
+      expect(downloadComponent.props.href).to.equal('https://download-url-1');
     });
     it('should return undefined if links are null', () => {
       testItem.links = null;
@@ -660,7 +662,7 @@ describe('Edition Card', () => {
         expect(linkComponent.prop('to').search).to.equal('?url=https://archive.org/details/blithedaleromanc00hawtrich');
       });
       it('Edition has Download link', () => {
-        expect(editionData.downloadLink).to.equal('https://catalog.hathitrust.org/api/volumes/oclc/39113388.html');
+        expect(editionData.downloadLink.props.href).to.equal('https://catalog.hathitrust.org/api/volumes/oclc/39113388.html');
       });
     });
 

--- a/test/unit/ResultsList.test.js
+++ b/test/unit/ResultsList.test.js
@@ -107,7 +107,7 @@ describe('Results List', () => {
         expect(linkComponent.prop('to').search).to.equal('?url=https://archive.org/details/blithedaleromanc00hawtrich');
       });
       it('result data has download link', () => {
-        expect(resultsData.editionInfo.downloadLink).to.equal('https://catalog.hathitrust.org/api/volumes/oclc/39113388.html');
+        expect(resultsData.editionInfo.downloadLink.props.href).to.equal('https://catalog.hathitrust.org/api/volumes/oclc/39113388.html');
       });
       it('result data has editions link', () => {
         expect(mount(<span>{resultsData.editionsLinkElement}</span>).text()).to.equal('View All 17 Editions');


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-885)

### This PR does the following:
- Adds `onClick` events to the "Read Online" and "Download" buttons in edition cards that trigger GA tracking events that record which button was clicked, the source of the edition being accessed and the title of the work

### Testing requirements & instructions: 
-  Verify that the onClick triggers are present in all cases
- (Optional) trigger an event and verify that it appears in the Google Analytics reports
