### PR TITLE
RENO-1153-update-dgx-react-footer-to-0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## [0.8.6]
+### Added
+- Updating @nypl/dgx-react-footer to 0.5.4.
+
 ## [0.8.5]
 ### Added
 - Google Analytics Events for Read Online and Download links

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## NYPL ResearchNow
 
 ### Version
-> 0.3.1
+> 0.8.6
 
 ### ResearchNow Search & Retrieval Application
 [![GitHub version](https://badge.fury.io/gh/NYPL%2Fsfr-bookfinder-front-end.svg)](https://badge.fury.io/gh/NYPL%2Fsfr-bookfinder-front-end)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rnw-front-end-development",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "ResearchNow front-end application for NYPL's newest search & retrieval platform.",
   "author": "NYPL Digital",
   "main": "index.js",
@@ -69,7 +69,7 @@
     "@emotion/core": "^10.0.27",
     "@nypl/design-system-react-components": "0.0.17",
     "@nypl/design-system-styles": "0.0.13",
-    "@nypl/dgx-react-footer": "0.5.2",
+    "@nypl/dgx-react-footer": "0.5.4",
     "@nypl/dgx-svg-icons": "0.3.9",
     "@nypl/nypl-data-api-client": "1.0.0",
     "axios": "^0.19.1",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.4
- The footer update removes the Kievit font, Tumbler icon, and adds [system-font-css](https://github.com/jonathantneal/system-font-css) according to this [migration guide](https://docs.google.com/document/d/1gErDfbmTuKvSUkmfFnhRh9BAF1CCqUl66koTAtOZmdU/edit#)-  
