### PR TITLE
Hotfix add variable to destroy action

### DIFF
--- a/.github/workflows/destroy-branch-qa.yaml
+++ b/.github/workflows/destroy-branch-qa.yaml
@@ -18,6 +18,8 @@ jobs:
           aws-region: us-east-1
 
       - name: Delete Service from ECS cluster
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
           aws ecs delete-service \
             --cluster sfr-pipeline-qa \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adds integration tests to landing and search pages
 - Adds temporary deployment of feature branches for QA testing
 - Refactors app to use `API_URL` and `APP_ENV` environment variables
+- Resolve issue with temporary testing environment teardown GHA
 
 ## [0.9.3]
 


### PR DESCRIPTION
### This PR does the following:
The action that tears down the temporary testing environment was missing an environment variable that provided the branch name. This resulted in the process erroring. Adding the variable resolves the problem.

### Testing requirements & instructions: 
No testing required. An identical fix was necessary on the back-end repo and resolved the issue.