### PR TITLE
HOTFIX Specify API port

### DIFF
--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -40,8 +40,8 @@ jobs:
         env:
           BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          servicearn=$(aws ecs describe-services --cluster sfr-pipeline-qa --services $BRANCH_NAME-qa | jq '.services[0].serviceArn')
-          existingtask=$(if [[ "$servicearn" != "null" ]]; then echo true; else echo false; fi)
+          taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --service-name $BRANCH_NAME-qa | jq '.taskArns[0]')
+          existingtask=$(if [[ "$taskarn" != "null" ]]; then echo true; else echo false; fi)
           echo $existingtask
           echo "::set-output name=existingtask::$existingtask"
 

--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -37,9 +37,11 @@ jobs:
 
       - name: Check if task and service already exists
         id: task-present-check
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
-          existingtask=$(if [[ "$taskarn" != "null" ]]; then echo true; else echo false; fi)
+          servicearn=$(aws ecs describe-services --cluster sfr-pipeline-qa --services $BRANCH_NAME-qa | jq '.services[0].serviceArn')
+          existingtask=$(if [[ "$servicearn" != "null" ]]; then echo true; else echo false; fi)
           echo $existingtask
           echo "::set-output name=existingtask::$existingtask"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Adds integration tests to landing and search pages
 - Adds temporary deployment of feature branches for QA testing
 - Refactors app to use `API_URL` and `APP_ENV` environment variables
-- Resolve issue with temporary testing environment teardown GHA
+- Resolve issue with temporary testing environment teardown GHA and API port
 
 ## [0.9.3]
 

--- a/task-definition.json
+++ b/task-definition.json
@@ -62,7 +62,7 @@
                 },
                 {
                     "name": "API_URL",
-                    "value": "localhost:80"
+                    "value": "http://localhost:80"
                 }
 
             ]

--- a/task-definition.json
+++ b/task-definition.json
@@ -62,7 +62,7 @@
                 },
                 {
                     "name": "API_URL",
-                    "value": "127.0.0.1"
+                    "value": "localhost:80"
                 }
 
             ]


### PR DESCRIPTION
### This PR does the following:
The front-end application is calling the local API instance, but on the incorrect port, this attempts to fix the issue by statically specifying that port.

### Testing requirements & instructions: 
Verify that the app is able to query the API 
