### PR TITLE
HOTFIX Update branch tags

### DIFF
--- a/.github/workflows/build-branch-qa.yaml
+++ b/.github/workflows/build-branch-qa.yaml
@@ -29,11 +29,11 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: sfr_ingest_pipeline
-          IMAGE_TAG: ${{ github.sha }}
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_NAME .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_NAME
+          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH_NAME"
 
       - name: Check if task and service already exists
         id: task-present-check
@@ -52,7 +52,7 @@ jobs:
  
       - name: Populate task definition for API container
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
-        id: render-api-container
+        id: render-app-container
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: task-definition.json
@@ -61,7 +61,7 @@ jobs:
 
       - name: Deploy task definition to ECS
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
-        run: aws ecs register-task-definition --cli-input-json file://task-definition.json
+        run: aws ecs register-task-definition --cli-input-json file://${{ steps.render-app-container.outputs.task-definition }}
 
       - name: Create new service in ECS cluster
         if: ${{ steps.task-present-check.outputs.existingtask == 'false' }}
@@ -86,8 +86,10 @@ jobs:
 
       - name: Get ARN of branch QA task
         id: get-task-arn
+        env:
+          BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --family sfr-pipeline-testing | jq '.taskArns[0]')
+          taskarn=$(aws ecs list-tasks --cluster sfr-pipeline-qa --service $BRANCH_NAME-qa | jq '.taskArns[0]')
           echo "::set-output name=taskarn::$taskarn"
 
       - name: Get deployed ENI for service


### PR DESCRIPTION
This commit includes one fix and one improvement to the QA deployment process.

The fix is to correct a regression that was causing the `latest` tag for the application container to be deployed. The updated `task-definition` was not being passed in the correct step

The improvement is to tag images with the branch name instead of the git hash, this makes them more identifiable.