### PR TITLE
Sfr 1073 add favicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Adds temporary deployment of feature branches for QA testing
 - Refactors app to use `API_URL` and `APP_ENV` environment variables
 - Resolve issue with temporary testing environment teardown GHA and API port
+- Add favicon
 
 ## [0.9.3]
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,6 +7,7 @@ import Footer from "@nypl/dgx-react-footer";
 import { documentTitles } from "~/src/constants/labels";
 import Feedback from "~/src/components/Feedback/Feedback";
 import Loading from "../Loading/Loading";
+import appConfig from "~/config/appConfig";
 /**
  * Container class providing header, footer,
  * and other set up information to all its children.
@@ -52,6 +53,7 @@ const Layout: React.FC<any> = ({ children }) => {
     <div className="layout-container nypl-ds nypl--research">
       <Head>
         <title>{setTitle(router)}</title>
+        <link rel="icon" href={appConfig.favIconPath} />
         <Header
           skipNav={{ target: "mainContent" }}
           navData={navConfig.current}


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1073)

### This PR does the following:
This simply sets the favicon link for the site in the `head` element. It does so alongside the `title` element which means that this should be easy to locate/update in the future if necessary.

The favicon URL is loaded from the `appConfig` file and should be changed there if the icon itself changes.

### Testing requirements & instructions: 
The testing environment should be reviewed to confirm that the icon appears on all pages
