### PR TITLE
Removed extra <h1> and made the header a link

### DIFF
--- a/src/__tests__/Search.test.tsx
+++ b/src/__tests__/Search.test.tsx
@@ -39,10 +39,13 @@ describe("Renders Search Results Page", () => {
     });
   });
 
-  test("Breadcrumbs link to homepage", () => {
-    expect(
-      screen.getByRole("link", { name: "Digital Research Books Beta" })
-    ).toHaveAttribute("href", "/");
+  test("Digital Research Books Beta links to homepage", () => {
+    const homepagelinks = screen.getAllByRole("link", {
+      name: "Digital Research Books Beta",
+    });
+    homepagelinks.forEach((link) => {
+      expect(link).toHaveAttribute("href", "/");
+    });
   });
   test("DRB Header is shown", () => {
     expect(

--- a/src/components/SearchHeader/SearchHeader.scss
+++ b/src/components/SearchHeader/SearchHeader.scss
@@ -21,8 +21,26 @@
         flex: 1 1 50%;
     }   width: 100%;
 
-    h1 { 
-        color: var(--ui-white); 
+    h2 { 
+        //Uses the heading-xl mixin from design system
+        color: var(--ui-white);
+        font-size: var(--font-size-4);
+        font-weight: 300;
+        letter-spacing: 0;
+        line-height: 1.1;
+        margin: 0.25em 0 0.5em;
+        width: auto;
+      
+        .link {
+          color: inherit;
+          text-decoration: none;
+      
+          &:hover {
+            color: var(--ui-gray-light);
+            text-decoration: underline;
+          }
+        }
+
         @media (min-width: #{$breakpoint-medium}) {
             max-width: 300px;
         }

--- a/src/components/SearchHeader/SearchHeader.tsx
+++ b/src/components/SearchHeader/SearchHeader.tsx
@@ -17,7 +17,9 @@ const SearchHeader: React.FC<{ searchQuery?: SearchQuery }> = ({
   return (
     <div className="search-header-container">
       <div className="search-header" aria-label="Digital Research Books Beta">
-        <DS.Heading level={1} id="1" text="Digital Research Books Beta" />
+        <DS.Heading level={2}>
+          <Link to="/">Digital Research Books Beta</Link>
+        </DS.Heading>
         <SearchForm searchQuery={searchQuery} />
         <Link
           to={{

--- a/src/components/Work/Work.test.tsx
+++ b/src/components/Work/Work.test.tsx
@@ -19,10 +19,13 @@ describe("Renders Work component when given valid work", () => {
       </MockNextRouterContextProvider>
     );
   });
-  test("Breadcrumbs link to homepage", () => {
-    expect(
-      screen.getByRole("link", { name: breadcrumbTitles.home })
-    ).toHaveAttribute("href", "/");
+  test("Digital Research Books Beta links to homepage", () => {
+    const homepagelinks = screen.getAllByRole("link", {
+      name: "Digital Research Books Beta",
+    });
+    homepagelinks.forEach((link) => {
+      expect(link).toHaveAttribute("href", "/");
+    });
   });
   test("Shows Header with Searchbar", () => {
     expect(


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1071)

### This PR does the following:
- Removes h1 duplication by removing it from the search header.  
- Restyles the search header to look like a header
- Changes the search header to be a link 

### Testing requirements & instructions: 
-  
