### PR TITLE
NOREF Add production build step to GHA

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -1,0 +1,50 @@
+# On merge to production,
+# build a container and deploy to ECR
+name: Publish Production
+on:
+  pull_request:
+    branches: [production]
+    types: [closed]
+
+jobs:
+  publish_qa:
+    name: Publish image to ECR
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - id: nvmrc
+        run: echo ::set-output name=NODE_VERSION::$(cat .nvmrc)
+
+      - name: Set up node with version from nvm
+        uses: actions/setup-node@v2
+        with: { node-version: "${{ steps.nvmrc.outputs.NODE_VERSION }}" }
+
+      - name: Configure AWS credentials from Test account
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: sfr-front-end
+          IMAGE_TAG: ${{ github.sha }}
+          AIRTABLE_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+        run: |
+          docker build --build-arg airtable_api_key=$AIRTABLE_KEY -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Force ECS Update
+        run: |
+          aws ecs update-service --cluster sfr-front-end-production --service sfr-front-end-production --force-new-deployment


### PR DESCRIPTION
### This PR does the following:
- Adds a production build action that is triggered against merges to the production branch (automated production deployments)

### Testing requirements & instructions: 
-  This can't be tested and should be verified to work properly before the formal launch on 6/9 (aka merge this along with a functional change into production and be sure that the functional change deploys properly)
