### PR TITLE
SFR-1193 Run rspec tests

### DIFF
--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout rspec repo
-        run: git clone 'https://"$PA_TOKEN"@github.com/nypl/rspec_researchNow.git'
+        run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git
 
       - name: Test
         run: npm run test

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -1,0 +1,69 @@
+name: Rspec Regression Testing
+
+on:
+  # will run on all PRs that are opened or updated (synchronized)
+  pull_request:
+    branches: [production]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  regression-test:
+    name: Run rspec regression tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ["3.0.0"]
+
+    env:
+      PA_TOKEN: ${{ secrets.CLONE_PAT }}
+      BASE_URL: ${{ secrets.RSPEC_TEST_URL }}
+      SEARCH_TERM: ${{ secrets.RSPEC_TEST_STRING }}
+      TEST_DRIVER: ${{ secrets.RSPEC_TEST_DRIVER }}
+
+    services:
+      chrome:
+        image: selenium/standalone-chrome
+
+    steps:
+      - name: Checkout rspec repo
+        run: git clone 'https://"$PA_TOKEN"@github.com/nypl/rspec_researchNow.git'
+
+      - name: Test
+        run: npm run test
+
+      - name: Run 10sanity_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/10sanity_spec.rb
+
+      - name: Run 100homepage_elements_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/100homepage_elements_spec.rb
+
+      - name: Run 101header_elements_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/101header_elements_spec.rb
+
+      - name: Run 102footer_elements_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/102footer_elements_spec.rb
+
+      - name: Run 110keyword_search_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/110keyword_search_spec.rb
+
+      - name: Run 112author_search_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/112author_search_spec.rb
+
+      - name: Run 113subject_search_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/113subject_search_spec.rb
+
+      - name: Run 140frontend_to_end_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/140frontend_to_end_spec.rb
+
+      - name: Run 120filter_language_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/120filter_language_spec.rb
+
+      - name: Run 122filter_pubyear_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/122filter_pubyear_spec.rb
+
+      - name: Run 200advanced_search_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/200advanced_search_spec.rb
+
+      - name: Run 201advanced_search_pubyear_spec.rb
+        run: bundle exec rspec -r ./spec/support/prod.rb spec/201advanced_search_pubyear_spec.rb
+

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -32,7 +32,7 @@ jobs:
           bundler-cache: true
 
       - name: Checkout rspec repo
-        run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git
+        run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git .
 
       - name: Run regression tests (prefixed with number code)
         run: bundle exec rspec -r ./spec/support/prod.rb --pattern spec/[12]?[0-9]*_spec.rb

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -28,39 +28,6 @@ jobs:
       - name: Checkout rspec repo
         run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git
 
-      - name: Run 10sanity_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/10sanity_spec.rb
-
-      - name: Run 100homepage_elements_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/100homepage_elements_spec.rb
-
-      - name: Run 101header_elements_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/101header_elements_spec.rb
-
-      - name: Run 102footer_elements_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/102footer_elements_spec.rb
-
-      - name: Run 110keyword_search_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/110keyword_search_spec.rb
-
-      - name: Run 112author_search_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/112author_search_spec.rb
-
-      - name: Run 113subject_search_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/113subject_search_spec.rb
-
-      - name: Run 140frontend_to_end_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/140frontend_to_end_spec.rb
-
-      - name: Run 120filter_language_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/120filter_language_spec.rb
-
-      - name: Run 122filter_pubyear_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/122filter_pubyear_spec.rb
-
-      - name: Run 200advanced_search_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/200advanced_search_spec.rb
-
-      - name: Run 201advanced_search_pubyear_spec.rb
-        run: bundle exec rspec -r ./spec/support/prod.rb spec/201advanced_search_pubyear_spec.rb
+      - name: Run regression tests (prefixed with number code)
+        run: bundle exec rspec -r ./spec/support/prod.rb --pattern spec/[12]?[0-9]*_spec.rb
 

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -3,7 +3,7 @@ name: Rspec Regression Testing
 on:
   # will run on all PRs that are opened or updated (synchronized)
   pull_request:
-    branches: [production, development]
+    branches: [production]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -3,7 +3,7 @@ name: Rspec Regression Testing
 on:
   # will run on all PRs that are opened or updated (synchronized)
   pull_request:
-    branches: [production]
+    branches: [production, development]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Set up Ruby
-        uses: ruby/setup-ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -25,14 +25,14 @@ jobs:
         image: selenium/standalone-chrome
 
     steps:
+      - name: Checkout rspec repo
+        run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git .
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-
-      - name: Checkout rspec repo
-        run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git .
 
       - name: Run regression tests (prefixed with number code)
         run: bundle exec rspec -r ./spec/support/prod.rb --pattern spec/[12]?[0-9]*_spec.rb

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Checkout rspec repo
         run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git
 
-      - name: Test
-        run: npm run test
-
       - name: Run 10sanity_spec.rb
         run: bundle exec rspec -r ./spec/support/prod.rb spec/10sanity_spec.rb
 

--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -25,6 +25,12 @@ jobs:
         image: selenium/standalone-chrome
 
     steps:
+      - name: Set up Ruby
+        uses: ruby/setup-ruby
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
       - name: Checkout rspec repo
         run: git clone https://$PA_TOKEN@github.com/nypl/rspec_researchNow.git
 


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1193)

### This PR does the following:
- Adds a GHA to run the rspec integration test suite against the application currently deployed on QA

### Testing requirements & instructions: 
-  Verify that the GHA runs and that the integration test pass (and have run against the proper application)

### Notes
This executes the integration test suite when PRs are opened against production. This should protect against obvious regressions and provides a way of running automated tests in a way that picks up new tests without dev/QA intervention. This PR runs these tests against development to verify that the action works as intended but will be updated to run only against production before being merged in.