### PR TITLE
SFR-1235 Proxy URL Fix

### DIFF
--- a/src/components/ReaderLayout/ReaderLayout.tsx
+++ b/src/components/ReaderLayout/ReaderLayout.tsx
@@ -10,13 +10,13 @@ import { formatUrl, truncateStringOnWhitespace } from "~/src/util/Util";
 import { MAX_TITLE_LENGTH } from "~/src/constants/editioncard";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { proxyUrl } from "~/src/lib/api/SearchApi";
 const WebReader = dynamic(() => import("@nypl/web-reader"), { ssr: false });
 //The NYPL wrapper that wraps the Reader pages.
-const ReaderLayout: React.FC<{ linkResult: LinkResult }> = (props) => {
+const ReaderLayout: React.FC<{ linkResult: LinkResult, proxyUrl: string }> = (props) => {
   const router = useRouter();
   const origin = router.basePath;
   const link: ApiLink = props.linkResult.data;
+  const proxyUrl = props.proxyUrl;
   const url = formatUrl(link.url);
   const edition = link.work.editions[0];
 

--- a/src/lib/api/SearchApi.ts
+++ b/src/lib/api/SearchApi.ts
@@ -16,8 +16,6 @@ const recordUrl = apiUrl + recordPath;
 const editionUrl = apiUrl + editionPath;
 const readUrl = apiUrl + readPath;
 const languagesUrl = apiUrl + languagesPath;
-export const proxyUrl =
-  process.env["NEXT_PUBLIC_PROXY_URL"] || apiUrl + "/utils/proxy?proxy_url=";
 
 const defaultWorkQuery: WorkQuery = {
   identifier: "",
@@ -28,6 +26,11 @@ const defaultEditionQuery = {
   editionIdentifier: "",
   showAll: "true",
 };
+
+export const proxyUrlConstructor = () => {
+  return process.env["NEXT_PUBLIC_PROXY_URL"]
+    || apiUrl + "/utils/proxy?proxy_url=";
+}
 
 export const searchResultsFetcher = async (apiQuery: ApiSearchQuery) => {
   if (!apiQuery || !apiQuery.query) {

--- a/src/pages/read/[linkId].tsx
+++ b/src/pages/read/[linkId].tsx
@@ -1,13 +1,17 @@
 import React from "react";
 import ReaderLayout from "~/src/components/ReaderLayout/ReaderLayout";
-import { readFetcher } from "~/src/lib/api/SearchApi";
+import { readFetcher, proxyUrlConstructor } from "~/src/lib/api/SearchApi";
 import { LinkResult } from "~/src/types/LinkQuery";
 
 export async function getServerSideProps(context: any) {
   try {
     const linkResult: LinkResult = await readFetcher(context.query.linkId);
+    const proxyUrl: string = proxyUrlConstructor();
     return {
-      props: { linkResult: linkResult },
+      props: {
+          linkResult: linkResult,
+          proxyUrl: proxyUrl,
+      },
     };
   } catch (e) {
     return {
@@ -17,6 +21,6 @@ export async function getServerSideProps(context: any) {
 }
 
 const WebReaderPage: React.FC<any> = (props) => {
-  return <ReaderLayout linkResult={props.linkResult} />;
+  return <ReaderLayout linkResult={props.linkResult} proxyUrl={props.proxyUrl} />;
 };
 export default WebReaderPage;

--- a/task-definition.json
+++ b/task-definition.json
@@ -17,12 +17,12 @@
             "essential": true,
             "command": [
                 "--process", "APIProcess",
-                "--environment", "qa"
+                "--environment", "development"
             ],
             "environment": [
                 {
                     "name": "ENVIRONMENT",
-                    "value": "qa"
+                    "value": "development"
                 },
                 {
                     "name": "ELASTICSEARCH_HOST",


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1235)

### This PR does the following:
The `proxyUrl` is provided to the new web reader component to enable the display of PDFs. This relies on server-side only environment variables to construct this value (specifically `API_URL`) and was unable to retrieve these values.

This updates the component by constructing the value on the server-side and passing it in as a new prop. A simple method constructs the string and should make it available in all cases.

### Testing requirements & instructions: 
The test deployment here should successfully be able to load PDF files in the web reader via the local proxy
