### PR TITLE
Upgrades web-reader to 0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.11.1",
+  "version": "0.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -321,9 +321,9 @@
       }
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz",
+      "integrity": "sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
       }
@@ -2216,9 +2216,9 @@
       "integrity": "sha512-5grNReXumLM1+zj5lnZJx5h8KEk1Aa2/tyogTiLAhB06RrpaH83WbINhzL1eJeMbz4h/NFWrj8SUIoqLPHM9tA=="
     },
     "@nypl/web-reader": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@nypl/web-reader/-/web-reader-0.2.4.tgz",
-      "integrity": "sha512-QnTh4Fjlo5s4u/rBQ2cizzRVYIAD0jew7Hz6kIBeS9cz5j46YNIXz5/QeVkxRKj0tupD+iKDE2b59bG0bFu3Cg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@nypl/web-reader/-/web-reader-0.2.5.tgz",
+      "integrity": "sha512-PA2FlQT/vHoXnxJSFOWidsDBpg7Pn6e62qp4VC85JlTJl76M2GUKFh77RgCRQxpTg9CmUrXegMJPC9sLyhSKmw==",
       "requires": {
         "@chakra-ui/react": "^1.6.9",
         "@d-i-t-a/reader": "^2.0.0-beta.4",
@@ -2228,6 +2228,7 @@
         "framer-motion": "^4.1.6",
         "node-fetch": "^2.6.1",
         "react-icons": "^4.3.1",
+        "react-intersection-observer": "^8.32.2",
         "react-pdf": "^5.3.2",
         "workbox-expiration": "^6.2.4",
         "workbox-precaching": "^6.2.4",
@@ -2236,9 +2237,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
-          "integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+          "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -10966,11 +10967,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
-    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -13415,6 +13411,11 @@
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ=="
     },
+    "react-intersection-observer": {
+      "version": "8.32.2",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.32.2.tgz",
+      "integrity": "sha512-QTcea+n28AvOHbTku+jErfQqknbc4Nuh7EUNik8p/JMN56W2Jhjs+qcYZzQhAoyLX8pZD0QXpYX0lW87faackQ=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -13955,17 +13956,16 @@
       }
     },
     "sanitize-html": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.5.2.tgz",
-      "integrity": "sha512-sJ1rO2YixFIqs2kIcEUb6PTrCjvz8DMq1XqWWuy0kjgjrn58GNLK1DKSIRybFZDO1WNgsEgD+WiEzTEYS8xEug==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.5.3.tgz",
+      "integrity": "sha512-DGATXd1fs/Rm287/i5FBKVYSBBUL0iAaztOA1/RFhEs4yqo39/X52i/q/CwsfCUG5cilmXSBmnQmyWfnKhBlOg==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
         "htmlparser2": "^6.0.0",
         "is-plain-object": "^5.0.0",
-        "klona": "^2.0.3",
         "parse-srcset": "^1.0.2",
-        "postcss": "^8.0.2"
+        "postcss": "^8.3.11"
       },
       "dependencies": {
         "escape-string-regexp": {
@@ -13977,6 +13977,26 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "nanoid": {
+          "version": "3.1.30",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+          "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
+        },
+        "picocolors": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+        },
+        "postcss": {
+          "version": "8.3.11",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
+          "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+          "requires": {
+            "nanoid": "^3.1.30",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^0.6.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@nypl/design-system-react-components": "~0.21.2",
     "@nypl/dgx-header-component": "git+https://git@github.com/NYPL/dgx-header-component#reactupdate",
     "@nypl/dgx-react-footer": "0.5.8",
-    "@nypl/web-reader": "0.2.4",
+    "@nypl/web-reader": "^0.2.5",
     "@types/node": "^14.14.33",
     "@types/react": "^16.9.5",
     "css-loader": "^6.4.0",


### PR DESCRIPTION
No Jira Ticket

### This PR does the following:
- Updates @nypl/web-reader package so that PDF rendering performance enhancements in scrolling mode can be tested by QA

### Testing requirements & instructions: 
-  Load a large single-resource PDF in Firefox, Chrome, or Safari. The resource should render in scrolling mode without issue. Browser should not crash.