### PR TITLE
NOREF Add catalog secrets

### DIFF
--- a/.github/workflows/rspec-integration-tests.yml
+++ b/.github/workflows/rspec-integration-tests.yml
@@ -19,6 +19,8 @@ jobs:
       BASE_URL: ${{ secrets.RSPEC_TEST_URL }}
       SEARCH_TERM: ${{ secrets.RSPEC_TEST_STRING }}
       TEST_DRIVER: ${{ secrets.RSPEC_TEST_DRIVER }}
+      CATALOG_USERNAME: ${{ secrets.CATALOG_USERNAME }}
+      CATALOG_USER_PIN: ${{ secrets.CATALOG_USER_PIN }}
 
     services:
       chrome:


### PR DESCRIPTION
In order to test the EDD button the regression tests need to be able to log in to the NYPL catalog. These provide the QA credentials for doing so.

### Testing requirements & instructions: 
-  There is no testing here. Once merged into `development` the tests on the existing PR to `production` should pass
