### PR TITLE
SFR-1505: Fix back to search results bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGE LOG
+## [Pre-release]
+- Fix back to search results bug 
+
 ## [0.14.0]
 - Upgrade to NYPL Design System version 1.0.0
 - Decouples search query into separate states for each individual form field

--- a/src/util/LinkUtils.ts
+++ b/src/util/LinkUtils.ts
@@ -9,7 +9,7 @@ export const getBackUrl = (referer: string, host: string) => {
 };
 
 export const getBackToSearchUrl = (referer: string, host: string) => {
-  return isRefererInternal(referer, host) && referer.includes("search")
+  return isRefererInternal(referer, host) && referer.includes("/search")
     ? referer
     : null;
 };


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1505)

### This PR does the following:
- Changes the check for "search" to the endpoint "/search" to prevent links without the endpoint from being recognized as a search results link for prod, i.e. digital-re**search**-books-beta.nypl.org

### Testing requirements & instructions: 
-  
