### PR TITLE
SFR-1554: Fix absolute link issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGE LOG
 
+## [Pre-release]
+- Fix absolute link is prefixed by host issue
+
 ## [0.15.0]
 
 - add features and tests for item details pages

--- a/src/util/EditionCardUtils.tsx
+++ b/src/util/EditionCardUtils.tsx
@@ -316,7 +316,7 @@ export default class EditionCardUtils {
           </Link>
           <Link
             // Url starts with www
-            to={`//${eddLink.url}`}
+            to={`https://${eddLink.url}`}
             linkType="button"
             target="_blank"
           >


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1554)

### This PR does the following:
- Fixes the issue where the EDD absolute link is prefixed by the host. This is a result of upgrading Next.js to 12.2.5, which no longer allows absolute links without protocol (https).

### Testing requirements & instructions: 
-  
