### PR TITLE
Sam's CollectionItemCard edits: Refactors collection item card and collection utils

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,6 +1,6 @@
 module.exports = {
   default: {
-    // paths: ["playwright/features/**/*.feature"],
+    paths: ["playwright/features/**/*.feature"],
     import: ["playwright/tests/**/*.ts", "playwright/support/**/*.ts"],
   },
   worldParameters: {

--- a/src/components/CollectionItemCard/Author.tsx
+++ b/src/components/CollectionItemCard/Author.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { ApiSearchQuery } from "~/src/types/SearchQuery";
+import Link from "~/src/components/Link/Link";
+
+const Author: React.FC<{ author: string }> = ({ author }) => {
+  if (!author) return null;
+  const query: ApiSearchQuery = {
+    query: `author:${author}`,
+  };
+  return (
+    <Link
+      to={{
+        pathname: "/search",
+        query: query,
+      }}
+      className="link"
+    >
+      {author}
+    </Link>
+  );
+};
+
+export default Author;

--- a/src/components/CollectionItemCard/CollectionItemCard.tsx
+++ b/src/components/CollectionItemCard/CollectionItemCard.tsx
@@ -1,22 +1,14 @@
 import React from "react";
-
-import {
-  Box,
-  Card,
-  CardActions,
-  CardContent,
-  CardHeading,
-} from "@nypl/design-system-react-components";
-import Link from "../Link/Link";
+import { Card, CardContent } from "@nypl/design-system-react-components";
 import { useCookies } from "react-cookie";
 import { NYPL_SESSION_ID } from "~/src/constants/auth";
 import { OpdsPublication } from "~/src/types/OpdsModel";
 import CollectionUtils from "~/src/util/CollectionUtils";
-import {
-  MAX_PLACE_LENGTH,
-  MAX_PUBLISHER_NAME_LENGTH,
-} from "~/src/constants/editioncard";
-import { truncateStringOnWhitespace } from "~/src/util/Util";
+import Ctas from "~/src/components/CollectionItemCard/Ctas";
+import EditionYear from "~/src/components/CollectionItemCard/EditionYear";
+import PublisherAndLocation from "~/src/components/CollectionItemCard/PublisherAndLocation";
+import LicenseLink from "~/src/components/CollectionItemCard/LicenseLink";
+import LanguageDisplayText from "~/src/components/CollectionItemCard/LanguageDisplayText";
 
 // Creates an Collection item card out of the collectionItem object
 export const CollectionItemCard: React.FC<{
@@ -24,95 +16,9 @@ export const CollectionItemCard: React.FC<{
 }> = ({ collectionItem }) => {
   // cookies defaults to be undefined if not fonud
   const [cookies] = useCookies([NYPL_SESSION_ID]);
-
-  const EditionYear = () => {
-    const editionDisplay =
-      `${collectionItem.metadata.published} Edition` ?? "Edition Year Unknown";
-    return collectionItem ? (
-      <Link
-        to={{
-          pathname: collectionItem.links.find(
-            (link) => link.rel === "alternate"
-          ).href,
-        }}
-      >
-        {editionDisplay}
-      </Link>
-    ) : (
-      <>{editionDisplay}</>
-    );
-  };
-
-  const PublisherAndLocation = ({ pubPlace, publisher }) => {
-    const publisherDisplayLocation = (pubPlace: string) => {
-      return pubPlace
-        ? ` in ${truncateStringOnWhitespace(pubPlace, MAX_PLACE_LENGTH)}`
-        : "";
-    };
-
-    const publisherDisplayText = (publisher: string) => {
-      if (!publisher) return "";
-      return ` by ${truncateStringOnWhitespace(
-        publisher,
-        MAX_PUBLISHER_NAME_LENGTH
-      )}`;
-    };
-
-    const displayLocation = publisherDisplayLocation(pubPlace);
-    const displayName = publisherDisplayText(publisher);
-    if (!displayLocation && !displayName)
-      return <>Publisher and Location Unknown</>;
-    const publisherText = `Published${displayLocation}${displayName}`;
-    return <>{publisherText}</>;
-  };
-
-  // Language Display
-  const LanguageDisplayText = ({ language }) => {
-    if (language) {
-      const languageText = `Languages: ${language}`;
-      return <>{languageText}</>;
-    }
-    return <>Languages: Undetermined</>;
-  };
-
-  // Rights
-  const License = ({ rights }) => {
-    return rights ? (
-      <>License: {rights.rightsStatement}</>
-    ) : (
-      <>License: Unknown</>
-    );
-  };
-
-  const Ctas = ({ links, title, isLoggedIn }) => {
-    const readOnlineLink = CollectionUtils.getReadOnlineLink(links);
-    const downloadLink = CollectionUtils.getDownloadLink(links, title);
-
-    // If a digital version exists, link directly
-    if (readOnlineLink || downloadLink) {
-      return (
-        <>
-          <Box>{readOnlineLink}</Box>
-          <Box>{downloadLink}</Box>
-        </>
-      );
-    }
-
-    const eddLink = links
-      ? links.find(
-          (link) =>
-            link.identifier === "requestable" || link.identifier === "catalog"
-        )
-      : undefined;
-
-    // Offer EDD if available
-    if (eddLink !== undefined) {
-      const eddElement = CollectionUtils.getEddLinkElement(eddLink, isLoggedIn);
-      return <>{eddElement}</>;
-    }
-
-    return <>{CollectionUtils.getNoLinkElement(false)}</>;
-  };
+  const { links, metadata } = collectionItem;
+  const { locationCreated, published, rights, language, title, publisher } =
+    metadata;
 
   return (
     <Card
@@ -128,30 +34,20 @@ export const CollectionItemCard: React.FC<{
       id={`card-${CollectionUtils.getId(collectionItem.links)}`}
       p="s"
     >
-      <CardHeading level="three">
-        <EditionYear />
-      </CardHeading>
+      <EditionYear links={links} published={published} />
       <CardContent>
-        <Box>
-          <PublisherAndLocation
-            pubPlace={collectionItem.metadata.locationCreated}
-            publisher={collectionItem.metadata.publisher}
-          />
-        </Box>
-        <Box>
-          <LanguageDisplayText language={collectionItem.metadata.language} />
-        </Box>
-        <Link to="/license">
-          <License rights={collectionItem.metadata.rights} />
-        </Link>
-      </CardContent>
-      <CardActions display="flex" flexDir="column" whiteSpace="nowrap" gap={4}>
-        <Ctas
-          links={collectionItem.links}
-          title={collectionItem.metadata.title}
-          isLoggedIn={!!cookies[NYPL_SESSION_ID]}
+        <PublisherAndLocation
+          pubPlace={locationCreated}
+          publisher={publisher}
         />
-      </CardActions>
+        <LanguageDisplayText language={language} />
+        <LicenseLink rights={rights} />
+      </CardContent>
+      <Ctas
+        links={links}
+        title={title}
+        isLoggedIn={!!cookies[NYPL_SESSION_ID]}
+      />
     </Card>
   );
 };

--- a/src/components/CollectionItemCard/Ctas.tsx
+++ b/src/components/CollectionItemCard/Ctas.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { CardActions } from "@nypl/design-system-react-components";
+import { OpdsLink } from "~/src/types/OpdsModel";
+import ReadOnlineLink from "~/src/components/CollectionItemCard/ReadOnlineLink";
+import DownloadLink from "~/src/components/CollectionItemCard/DownloadLink";
+import EddLink from "~/src/components/CollectionItemCard/EddLink";
+import CollectionUtils from "~/src/util/CollectionUtils";
+
+const Ctas: React.FC<{
+  links: OpdsLink[];
+  title: string;
+  isLoggedIn: boolean;
+}> = ({ links, title, isLoggedIn }) => {
+  const eddLink = CollectionUtils.getEddLink(links);
+
+  return (
+    <CardActions display="flex" flexDir="column" whiteSpace="nowrap" gap={4}>
+      {links ? (
+        <>
+          {/* If a digital version exists, link directly */}
+          <ReadOnlineLink links={links} />
+          <DownloadLink links={links} title={title} />
+          {eddLink && <EddLink eddLink={eddLink} isLoggedIn={isLoggedIn} />}
+        </>
+      ) : (
+        "Not yet available"
+      )}
+    </CardActions>
+  );
+};
+
+export default Ctas;

--- a/src/components/CollectionItemCard/DownloadLink.tsx
+++ b/src/components/CollectionItemCard/DownloadLink.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Icon } from "@nypl/design-system-react-components";
+import CollectionUtils from "~/src/util/CollectionUtils";
+import Link from "~/src/components/Link/Link";
+import { OpdsLink } from "~/src/types/OpdsModel";
+import * as gtag from "~/src/lib/Analytics";
+import { formatUrl } from "~/src/util/Util";
+
+const DownloadLink: React.FC<{ links: OpdsLink[]; title: string }> = ({
+  links,
+  title,
+}) => {
+  const selectedLink = CollectionUtils.getDownloadLink(links);
+
+  if (selectedLink && selectedLink.href) {
+    return (
+      <Link
+        to={`${formatUrl(selectedLink.href)}`}
+        linkType="action"
+        onClick={() => {
+          gtag.drbEvents("Download", `${title}`);
+        }}
+      >
+        <Icon
+          name="download"
+          align="left"
+          size="small"
+          decorative
+          iconRotation="rotate0"
+        />
+        Download PDF
+      </Link>
+    );
+  }
+};
+
+export default DownloadLink;

--- a/src/components/CollectionItemCard/EddLink.tsx
+++ b/src/components/CollectionItemCard/EddLink.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box } from "@nypl/design-system-react-components";
+import { SCAN_AND_DELIVER_LINK } from "~/src/constants/links";
+import { OpdsLink } from "~/src/types/OpdsModel";
+import Link from "~/src/components/Link/Link";
+
+export const EddLink: React.FC<{
+  eddLink: OpdsLink;
+  isLoggedIn: boolean;
+}> = ({ eddLink, isLoggedIn }) => {
+  if (isLoggedIn) {
+    return (
+      <>
+        <Box whiteSpace="initial">You can request a partial scan via NYPL</Box>
+        <Link to={SCAN_AND_DELIVER_LINK} target="_blank">
+          Scan and Deliver
+        </Link>
+        <Link
+          // Url starts with www
+          to={`https://${eddLink.href}`}
+          linkType="button"
+          target="_blank"
+        >
+          Request
+        </Link>
+      </>
+    );
+  } else {
+    return (
+      <>
+        May be available via NYPL<br></br>
+        <Link
+          to={`https://login.nypl.org/auth/login?redirect_uri=${encodeURIComponent(
+            window.location.href
+          )}`}
+          linkType="button"
+        >
+          Log in for options
+        </Link>
+      </>
+    );
+  }
+};
+
+export default EddLink;

--- a/src/components/CollectionItemCard/EditionYear.tsx
+++ b/src/components/CollectionItemCard/EditionYear.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { CardHeading } from "@nypl/design-system-react-components";
+import Link from "~/src/components/Link/Link";
+import { OpdsLink } from "~/src/types/OpdsModel";
+import CollectionUtils from "~/src/util/CollectionUtils";
+
+const EditionYear: React.FC<{ published: number; links: OpdsLink[] }> = ({
+  published,
+  links,
+}) => {
+  const editionDisplay = published
+    ? `${published} Edition`
+    : "Edition Year Unknown";
+  const editionLink = CollectionUtils.getEditionLink(links);
+  return (
+    <CardHeading level="three">
+      {editionLink ? (
+        <Link
+          to={{
+            pathname: editionLink.href,
+          }}
+        >
+          {editionDisplay}
+        </Link>
+      ) : (
+        { editionDisplay }
+      )}
+    </CardHeading>
+  );
+};
+
+export default EditionYear;

--- a/src/components/CollectionItemCard/LanguageDisplayText.tsx
+++ b/src/components/CollectionItemCard/LanguageDisplayText.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Box } from "@nypl/design-system-react-components";
+
+const LanguageDisplayText: React.FC<{
+  language: string;
+}> = ({ language }) => {
+  return (
+    <Box as="p">
+      {language ? `Languages: ${language}` : "Languages: Undetermined"}
+    </Box>
+  );
+};
+
+export default LanguageDisplayText;

--- a/src/components/CollectionItemCard/LicenseLink.tsx
+++ b/src/components/CollectionItemCard/LicenseLink.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Rights } from "~/src/types/DataModel";
+import Link from "~/src/components/Link/Link";
+
+const LicenseLink: React.FC<{ rights: Rights }> = ({ rights }) => {
+  return (
+    <Link to="/license">
+      {rights ? `License: ${rights.rightsStatement}` : "License: Unknown"}
+    </Link>
+  );
+};
+
+export default LicenseLink;

--- a/src/components/CollectionItemCard/PublisherAndLocation.tsx
+++ b/src/components/CollectionItemCard/PublisherAndLocation.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Box } from "@nypl/design-system-react-components";
+import CollectionUtils from "~/src/util/CollectionUtils";
+
+const PublisherAndLocation: React.FC<{
+  pubPlace: string;
+  publisher: string;
+}> = ({ pubPlace, publisher }) => {
+  const displayLocation = CollectionUtils.getPublisherDisplayLocation(pubPlace);
+  const displayName = CollectionUtils.getPublisherDisplayText(publisher);
+
+  return (
+    <Box as="p">
+      {displayLocation && displayName
+        ? `Published${displayLocation}${displayName}`
+        : "Publisher and Location Unknown"}
+    </Box>
+  );
+};
+
+export default PublisherAndLocation;

--- a/src/components/CollectionItemCard/ReadOnlineLink.tsx
+++ b/src/components/CollectionItemCard/ReadOnlineLink.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { OpdsLink } from "~/src/types/OpdsModel";
+import CollectionUtils from "~/src/util/CollectionUtils";
+import { formatUrl } from "~/src/util/Util";
+import Link from "~/src/components/Link/Link";
+
+// "Read Online" button should only show up if the link was flagged as "reader" or "embed"
+const ReadOnlineLink: React.FC<{ links: OpdsLink[] }> = ({ links }) => {
+  const localLink = CollectionUtils.getReadLink(links, "readable");
+  const embeddedLink = CollectionUtils.getReadLink(links, "embedable");
+
+  // Prefer local link over embedded link
+  const readOnlineLink = localLink ?? embeddedLink;
+
+  if (!readOnlineLink) return null;
+
+  return (
+    <Link
+      to={{
+        pathname: formatUrl(readOnlineLink.href),
+      }}
+      linkType="button"
+    >
+      Read Online
+    </Link>
+  );
+};
+
+export default ReadOnlineLink;


### PR DESCRIPTION
### This PR does the following:
- Refactors CollectionUtils to include only functions that return OpdsLinks, text, or anything that isn't actually JSX
- Turns anything that renders JSX into a react component
- Separates all of the CollectionItemCard components into separate files for readability and easier testing

### Testing requirements & instructions: 
-  I didn't actually run this code while I was refactoring, so @jackiequach if you wouldn't mind running this branch to make sure everything runs as expected and looks ok!
