### PR TITLE
SFR-1711: Remove header/footer from web reader page 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add TOC for single resource PDFs
 - Refactored Playwright/Cucumber tests to use new dropdown action function
 - Refactored Playwright/Cucumber tests to use new text fill function
+- Hide Header and Footer components on /read pages using the Web Reader
 
 ## [0.17.1]
 - Replace dgx-header-component and DS Footer with Header/Footer components from nypl-header-app 

--- a/src/components/ReaderLayout/ReaderLayout.tsx
+++ b/src/components/ReaderLayout/ReaderLayout.tsx
@@ -92,16 +92,15 @@ const ReaderLayout: React.FC<{
     gtag.drbEvents("Read", `${link.work.title}`);
   }, [link]);
 
-  /**
-   * - Fetches manifest
-   * - Adds the TOC to the manifest
-   * - Generates a syncthetic url for the manifest to be passed to
-   * web reader.
-   * - Returns the synthetic url
-   */
-
   useEffect(() => {
     if (isRead) {
+      /**
+       * - Fetches manifest
+       * - Adds the TOC to the manifest
+       * - Generates a syncthetic url for the manifest to be passed to
+       * web reader.
+       * - Returns the synthetic url
+       */
       const fetchAndModifyManifest = async (url) => {
         setIsLoading(true);
         const response = await fetch(url);
@@ -125,6 +124,10 @@ const ReaderLayout: React.FC<{
       };
 
       fetchAndModifyManifest(url);
+
+      // hides header and footer components when web reader is displayed
+      document.getElementById("nypl-header").style.display = "none";
+      document.getElementById("nypl-footer").style.display = "none";
     }
   }, [isRead, pdfWorkerSrc, proxyUrl, url]);
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import type { AppProps } from "next/app";
 import gaUtils, * as gtag from "../lib/Analytics";
 import { useRouter } from "next/router";
@@ -50,6 +50,15 @@ const setTitle = (query: any) => {
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
+
+  useEffect(() => {
+    if (!isServerRendered()) {
+      if (!router.query.linkId) {
+        document.getElementById("nypl-header").style.display = "block";
+        document.getElementById("nypl-footer").style.display = "block";
+      }
+    }
+  });
 
   return (
     <>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -16,14 +16,12 @@ class MyDocument extends Document {
         <body>
           <div id="nypl-header"></div>
           <script
-            type="module"
             src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header"
             async
           ></script>
           <Main />
           <div id="nypl-footer"></div>
           <script
-            type="module"
             src="https://ds-header.nypl.org/footer.min.js?containerId=nypl-footer"
             async
           ></script>


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1711)

### This PR does the following:
- Hides the header/footer components if the web reader is displayed on /read endpoints.
- Removes type="module" from the Header/Footer scripts following updates from nypl-header-app.

### Testing requirements & instructions: 
-  
