### PR TITLE
SFR-1743/advance-search-language-filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## [Unreleased]
+
+- Add: SFR-1743: Verify advance search filters for DRB
+
 ## [0.17.3]
 
 - Upgrade to Next 13.4.7

--- a/playwright/features/advSearch.feature
+++ b/playwright/features/advSearch.feature
@@ -30,7 +30,7 @@ Feature: Advanced Search
         When I click the "advanced search link"
         Then I fill in the "keyword search box" with "Jane Austen"
         And I click the "Russian language checkbox"
-        And I click the "advance page search button"
+        And I click the "advanced search button"
         Then the "russian language subheader" should be displayed
         And the "russian language checkbox" should be checked
         And the "first read online button" should be displayed

--- a/playwright/features/advSearch.feature
+++ b/playwright/features/advSearch.feature
@@ -24,3 +24,13 @@ Feature: Advanced Search
         Then the "keyword heading" should be displayed
         And the "author heading" should be displayed
         And the "search result link" should be displayed
+
+    Scenario: As a user I select a language checkbox in advance search and verify the search results
+        Given I go to the "home" page
+        When I click the "advanced search link"
+        Then I fill in the "keyword search box" with "Jane Austen"
+        And I click the "Russian language checkbox"
+        And I click the "advance page search button"
+        Then the "russian language subheader" should be displayed
+        And the "russian language checkbox" should be checked
+        And the "first read online button" should be displayed

--- a/playwright/support/mappings.ts
+++ b/playwright/support/mappings.ts
@@ -25,7 +25,6 @@ export const elements = {
   "advanced search link": "[href='/advanced-search']",
   "advanced search button": "#submit-button",
   "search button": "#searchbar-button-search-bar",
-  "advance page search button": "//button[@id='submit-button']",
   "requestable checkbox": "text=Requestable",
   "login button": "[value='Submit']",
   "first login for options button": "text=Log in for options >> nth=0",

--- a/playwright/support/mappings.ts
+++ b/playwright/support/mappings.ts
@@ -25,12 +25,14 @@ export const elements = {
   "advanced search link": "[href='/advanced-search']",
   "advanced search button": "#submit-button",
   "search button": "#searchbar-button-search-bar",
+  "advance page search button": "//button[@id='submit-button']",
   "requestable checkbox": "text=Requestable",
   "login button": "[value='Submit']",
   "first login for options button": "text=Log in for options >> nth=0",
   "government documents checkbox":
     "span:text('Show only US government documents')",
-  "Latin language checkbox": "span:text('Latin')",
+  "Latin language checkbox": "`span:text('Latin')`",
+  "Russian language checkbox": "span:text('Russian')",
   "publication year apply button": "#year-filter-button",
   "first read online button": "text=Read Online >> nth=0",
   "first request button":
@@ -63,6 +65,7 @@ export const elements = {
   "advanced search clear button": "#reset-button",
   "keyword heading": "h1:text('IBM 1401')",
   "author heading": "h1:text('Laurie, Edward J.')",
+  "russian language subheader": "//div[contains(text(),'Russian')]",
   "search result link": "a:text('Computers and how they work')",
   "delivery location heading": "h2:text('Choose a delivery location')",
   "site name heading": "h1:text('Digital Research Books')",
@@ -132,4 +135,5 @@ export const inputs = {
   "1900": "1900",
   petroleum: "petroleum",
   "Robot Soccer": "Robot Soccer",
+  "Jane Austen": "Jane Austen",
 };

--- a/playwright/tests/assertions.spec.ts
+++ b/playwright/tests/assertions.spec.ts
@@ -12,3 +12,11 @@ Then(
     });
   }
 );
+
+Then(
+  /^the "([^"]*)" should be checked$/,
+  async function (this: CustomWorld, elementKey: keyof typeof elements) {
+    const element = elements[elementKey];
+    return expect(this.page.locator(element).isChecked()).toBeTruthy();
+  }
+);


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1743)

### This PR does the following:

This PR is a playwright tests for DRB advance search language filters. It verifies the followings

- when language checkbox is checked, after search we verify the language checkbox is checked on results page
- correct language titles are showing up
- read online button is being displayed

