### PR TITLE
SFR-1762: Update Adobe Analytic page names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add: SFR-1745: Add Playwright tests to GitHub Actions
 - Fix: SFR-1755: Fix Playwright test failures
 - Upgrade New Relic packages and update configuration
+- Update Adobe Analytics page names
 
 ## [0.17.3]
 

--- a/src/constants/analytics.ts
+++ b/src/constants/analytics.ts
@@ -1,1 +1,13 @@
 export const SITE_SECTION = "Digital Research Books";
+
+export const pageNames = {
+  home: "drb|home",
+  about: "drb|about",
+  license: "drb|license",
+  advancedSearch: "drb|advanced-search",
+  search: "drb|search|?",
+  workItem: "drb|work|",
+  editionItem: "drb|edition|",
+  readItem: "drb|read|",
+  collection: "drb|collection|",
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,8 @@ import { documentTitles } from "../constants/labels";
 import "@nypl/web-reader/dist/index.css";
 import { FeatureFlagProvider } from "../context/FeatureFlagContext";
 import { trackPageview } from "../lib/Analytics";
+import { pageNames } from "../constants/analytics";
+import { getQueryDecodedString } from "../util/SearchQueryUtils";
 
 /**
  * Determines if we are running on server or in the client.
@@ -42,19 +44,24 @@ const setTitle = (query: any) => {
 
 const sendAnalytics = (query: any, pathname: string) => {
   if (query.workId) {
-    trackPageview(documentTitles.workItem);
+    trackPageview(pageNames.workItem + query.workId);
   } else if (query.editionId) {
-    trackPageview(documentTitles.editionItem);
+    trackPageview(pageNames.editionItem + query.editionId);
   } else if (query.query) {
-    trackPageview(documentTitles.search);
+    const searchPageName = pageNames.search + getQueryDecodedString(query);
+    trackPageview(searchPageName);
   } else if (query.linkId) {
-    trackPageview(documentTitles.readItem);
+    trackPageview(pageNames.readItem + query.linkId);
   } else if (query.collectionId) {
-    trackPageview(documentTitles.readItem);
+    trackPageview(pageNames.collection + query.collectionId);
   } else if (pathname === "/advanced-search") {
-    trackPageview(documentTitles.advancedSearch);
+    trackPageview(pageNames.advancedSearch);
+  } else if (pathname === "/about") {
+    trackPageview(pageNames.about);
+  } else if (pathname === "/license") {
+    trackPageview(pageNames.license);
   } else {
-    trackPageview(documentTitles.home);
+    trackPageview(pageNames.home);
   }
 };
 
@@ -77,8 +84,6 @@ function MyApp({ Component, pageProps }: AppProps) {
         <title>{setTitle(router.query)}</title>
 
         <link rel="icon" href={appConfig.favIconPath} />
-
-        <script src={appConfig.analytics} async />
       </Head>
       <FeatureFlagProvider>
         <Component {...pageProps} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 import newrelic from "newrelic";
+import appConfig from "~/config/appConfig";
 
 type DocumentProps = {
   browserTimingHeader: string;
@@ -27,6 +28,7 @@ class MyDocument extends Document<DocumentProps> {
             type="text/javascript"
             dangerouslySetInnerHTML={{ __html: this.props.browserTimingHeader }}
           />
+          <script src={appConfig.analytics} async />
         </Head>
         <body>
           <div id="nypl-header"></div>

--- a/src/util/SearchQueryUtils.ts
+++ b/src/util/SearchQueryUtils.ts
@@ -17,6 +17,24 @@ export const getQueryString = (query: any) =>
     )
     .join("&");
 
+// For Adobe Analytics page_name
+export const getQueryDecodedString = (query: any) =>
+  query &&
+  Object.keys(query)
+    .map((key) =>
+      [key, query[key]]
+        .map((o) => {
+          let ret = o;
+          if (typeof o === "object") {
+            ret = JSON.stringify(o);
+          }
+          return encodeURI(ret);
+        })
+        .join("=")
+    )
+    .join("|&")
+    .replace(/%20/g, "+");
+
 export const findQueryForField = (queries: Query[], field: string): Query => {
   return queries.find((query: Query) => {
     return query.field === field;


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1762)

### This PR does the following:
- Update Adobe Analytics page names to fit [best practices](https://blastwiki.atlassian.net/wiki/spaces/NYPL/pages/7898713056097665227/Page+Name+Taxonomy+-+URLs+and+EXAMPLE+PAGE+NAMES)
- Move Adobe Analytics script to _document.tsx file 

### Testing requirements & instructions: 
-  
