### PR TITLE
SFR-1779: Fix incorrect prod args

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -77,8 +77,8 @@ jobs:
           --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY \
           --build-arg NEXT_PUBLIC_ADOBE_ANALYTICS="https://assets.adobedtm.com/1a9376472d37/8519dfce636d/launch-672b7e7f98ee.min.js" .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:production-latest
 
       - name: Force ECS Update
         run: |

--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -45,8 +45,8 @@ jobs:
           --build-arg NEW_RELIC_LICENSE_KEY=$NEW_RELIC_LICENSE_KEY \
           --build-arg NEXT_PUBLIC_ADOBE_ANALYTICS="https://assets.adobedtm.com/1a9376472d37/8519dfce636d/launch-bf8436264b01-development.min.js" .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:qa-latest
 
       - name: Force ECS Update
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGE LOG
 
+- Update production build to use unique ECR image tag
+
 ## [0.17.4]
 
 - Add id as subsection for "Read Online" CTA analytics tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGE LOG
 
-- Update production build to use unique ECR image tag
+- Update production and qa builds to use unique ECR image tag
 
 ## [0.17.4]
 


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1779)

### This PR does the following:
- Update the production yaml file to have a unique ECR image tag.

When our ECS cluster automatically restarts, the :latest docker build is pulled, which could be a QA build. This was never an issue since we had not used hard-coded build arguments prior to the New Relic instrumentation.
