### PR TITLE
NO-REF: Add Jackie and Sam as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Each line is a file pattern followed by one or more owners. These owners will be the default owners for everything in the repo. Unless a later match takes precedence,e ach owner will be requested for review when someone opens a pull request.
+* @samanthaandrews @jackiequach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Upgrade newrelic to v11.5.0
 - Upgrade Next.js to v13.5.4
+- Chore: Add Jackie and Sam as codeowners
 
 ## [0.17.5]
 


### PR DESCRIPTION
### This PR does the following:
- Adds Jackie and Sam as codeowners for the entire repo. This means Jackie or Sam will need to approve a PR before merging to `development`.
