### PR TITLE
SFR-1894: Add error modal for /fulfill errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add login buttons and info blurb UP items
 - Fix: Improve accessibility of CTAs and search bar
 - Update README to include info about testing login locally
+- Add error Modal for failed download requests
+- Update preview item to prioritize UP item
 
 ## [0.17.6]
 

--- a/src/components/EditionCard/ScanAndDeliverBlurb.tsx
+++ b/src/components/EditionCard/ScanAndDeliverBlurb.tsx
@@ -8,7 +8,7 @@ const ScanAndDeliverBlurb: React.FC = () => {
     <Flex
       alignItems={{ base: "start", md: "center" }}
       marginTop={{ base: "s", md: "m" }}
-      marginBottom={{ base: "s", md: null }}
+      marginBottom={{ base: "s", lg: "0" }}
     >
       <Icon name="errorOutline" size="small" />
       <Text size="caption" noSpace marginLeft="xxs">

--- a/src/components/EditionCard/UpBlurb.tsx
+++ b/src/components/EditionCard/UpBlurb.tsx
@@ -9,7 +9,7 @@ const UpBlurb: React.FC<{ publishers: Agent[] }> = ({ publishers }) => {
     <Flex
       alignItems={{ base: "start", md: "center" }}
       marginTop={{ base: "s", md: "m" }}
-      marginBottom={{ base: "s", md: null }}
+      marginBottom={{ base: "s", lg: "0" }}
     >
       <Icon name="errorOutline" size="small" />
       <Text size="caption" noSpace marginLeft="xxs">

--- a/src/lib/api/SearchApi.ts
+++ b/src/lib/api/SearchApi.ts
@@ -6,6 +6,8 @@ import { toLocationQuery } from "~/src/util/apiConversion";
 import { LinkResult } from "~/src/types/LinkQuery";
 import { ApiLanguageResponse } from "~/src/types/LanguagesQuery";
 import { LOGIN_LINK_BASE } from "~/src/constants/links";
+import { NextRouter } from "next/router";
+import { FulfillResult } from "~/src/types/FulfillQuery";
 
 const apiEnv = process.env["APP_ENV"];
 const apiUrl = process.env["API_URL"] || appConfig.api.url[apiEnv];
@@ -122,7 +124,11 @@ export const readFetcher = async (linkId: number) => {
   }
 };
 
-export const fulfillFetcher = async (fulfillUrl, nyplIdentityCookie) => {
+export const fulfillFetcher = async (
+  fulfillUrl: string,
+  nyplIdentityCookie: any,
+  router: NextRouter
+) => {
   const url = new URL(fulfillUrl);
   const res = await fetch(url.toString(), {
     method: "GET",
@@ -131,12 +137,16 @@ export const fulfillFetcher = async (fulfillUrl, nyplIdentityCookie) => {
     },
   });
   if (res.ok) {
-    return res.url;
+    router.push(res.url);
   } else {
     // redirect to the NYPL login page if access token is invalid
     if (res.status === 401) {
-      return LOGIN_LINK_BASE + encodeURIComponent(window.location.href);
+      router.push(LOGIN_LINK_BASE + encodeURIComponent(window.location.href));
     }
-    throw new Error(`Unable to download UP PDF`);
+    if (res.status === 404) {
+      const fulfillResult: FulfillResult = await res.json();
+      return fulfillResult.data;
+    }
   }
+  return undefined;
 };

--- a/src/types/FulfillQuery.ts
+++ b/src/types/FulfillQuery.ts
@@ -1,0 +1,6 @@
+export type FulfillResult = {
+  status?: number;
+  timestamp?: string;
+  responseType?: string;
+  data?: string;
+};

--- a/src/util/EditionCardUtils.tsx
+++ b/src/util/EditionCardUtils.tsx
@@ -151,6 +151,13 @@ export default class EditionCardUtils {
     });
   };
 
+  static getUpLink = (item: ApiItem): ItemLink => {
+    if (!item || !item.links) return undefined;
+    return item.links.find((link: ItemLink) => {
+      return !link.flags.edd && link.flags.nypl_login;
+    });
+  };
+
   // "Read Online" button should only show up if the link was flagged as "reader" or "embed"
   static getReadOnlineLink = (item: ApiItem) => {
     const localLink = EditionCardUtils.getReadLink(item, "reader");
@@ -179,6 +186,10 @@ export default class EditionCardUtils {
   static getPreviewItem(items: ApiItem[] | undefined) {
     if (!items) return undefined;
 
+    const firstUpItem = items.find((item) => {
+      return EditionCardUtils.getUpLink(item);
+    });
+
     const firstReadableItem = items.find((item) => {
       return (
         EditionCardUtils.getReadLink(item, "reader") ||
@@ -188,6 +199,7 @@ export default class EditionCardUtils {
 
     // If no readable link found, we just return any link that's not a catalog (edd)
     return (
+      firstUpItem ??
       firstReadableItem ??
       items.find((items) => {
         return items.links && items.links.find((link) => !link.flags.catalog);


### PR DESCRIPTION
Note: Apoorva agrees that Modals should not be used in the long run for error handling and will speak to DS to explore different types of notifications.

[Jira Ticket](http://jira.nypl.org/browse/SFR-1894)

### This PR does the following:
- Add modal for error handling of /fulfill
- Update getPreviewItem to prioritize the UP items

### Testing requirements & instructions: 
-  
