### PR TITLE
Hotfix: Fix failed to load pdf error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add login buttons and info blurb UP items
 - Fix: Improve accessibility of CTAs and search bar
 - Update README to include info about testing login locally
+- Hotfix: Update package-lock pdfjs-dist version
 
 ## [0.17.6]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19140,17 +19140,9 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "2.12.313",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.12.313.tgz",
-      "integrity": "sha512-1x6iXO4Qnv6Eb+YFdN5JdUzt4pAkxSp3aLAYPX93eQCyg/m7QFzXVWJHJVtoW48CI8HCXju4dSkhQZwoheL5mA==",
-      "peerDependencies": {
-        "worker-loader": "^3.0.8"
-      },
-      "peerDependenciesMeta": {
-        "worker-loader": {
-          "optional": true
-        }
-      }
+      "version": "2.6.347",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.6.347.tgz",
+      "integrity": "sha512-QC+h7hG2su9v/nU1wEI3SnpPIrqJODL7GTDFvR74ANKGq1AFJW16PH8VWnhpiTi9YcLSFV9xLeWSgq+ckHLdVQ=="
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -19749,9 +19741,8 @@
       }
     },
     "node_modules/react-pdf": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-5.7.2.tgz",
-      "integrity": "sha512-hdDwvf007V0i2rPCqQVS1fa70CXut17SN3laJYlRHzuqcu8sLLjEoeXihty6c0Ev5g1mw31b8OT8EwRw1s8C4g==",
+      "version": "5.3.2",
+      "integrity": "sha512-gT2xeUAUJem5UWNZYIQSPJAlPDbc3mIIhEgGK8P/qo1B68WIE4R4v3tNFYM9e5nqlKnGZG4Cd68SetlmnPejwA==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "file-loader": "^6.0.0",
@@ -19759,17 +19750,15 @@
         "make-event-props": "^1.1.0",
         "merge-class-names": "^1.1.1",
         "merge-refs": "^1.0.0",
-        "pdfjs-dist": "2.12.313",
-        "prop-types": "^15.6.2",
-        "tiny-invariant": "^1.0.0",
-        "tiny-warning": "^1.0.0"
+        "pdfjs-dist": "2.6.347",
+        "prop-types": "^15.6.2"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
       },
       "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.3.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.3.0 || ^17.0.0-0",
+        "react-dom": "^16.3.0 || ^17.0.0-0"
       }
     },
     "node_modules/react-popper": {
@@ -21801,11 +21790,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",


### PR DESCRIPTION
### This PR does the following:
- Fixes issue where PDF does not load on web reader due to pdfjs-dist version mismatch. Updates the version in package-lock.json

### Testing requirements & instructions: 
-  
