### PR TITLE
NO-REF: Add Kristo, Jiayong, and Olivia as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Each line is a file pattern followed by one or more owners. These owners will be the default owners for everything in the repo. Unless a later match takes precedence,e ach owner will be requested for review when someone opens a pull request.
-* @samanthaandrews @jackiequach
+* @samanthaandrews @jackiequach @kristojorg @Toxiapo @oliviawongnyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Update preview item to prioritize UP item
 - Hotfix: Update package-lock pdfjs-dist version
 - Remove featured edition logic from frontend
+- Chore: Add Krist, Jiayong, and Olivia as codeowners
 
 ## [0.17.6]
 


### PR DESCRIPTION
### This PR does the following:
- Adds Kristo, Jiayong, and Olivia as codeowners
 
### Testing requirements & instructions: 
-  
