### PR TITLE
NO-REF: Fix error for edition and work pages

### DIFF
--- a/src/components/EditionDetail/Edition.tsx
+++ b/src/components/EditionDetail/Edition.tsx
@@ -200,9 +200,10 @@ const Edition: React.FC<{ editionResult: EditionResult; backUrl?: string }> = (
       )}
       <SimpleGrid columns={1} gap="s">
         {edition.instances
-          .filter(
-            (instance) => instance.instance_id !== featuredInstance.instance_id
-          )
+          .filter((instance) => {
+            if (!featuredInstance) return true;
+            return instance.instance_id !== featuredInstance.instance_id;
+          })
           .map((instance) => (
             <InstanceCard
               key={instance.instance_id}

--- a/src/util/EditionCardUtils.tsx
+++ b/src/util/EditionCardUtils.tsx
@@ -188,7 +188,7 @@ export default class EditionCardUtils {
 
     const firstItem = items[0];
 
-    return firstItem.links ? firstItem : undefined;
+    return firstItem && firstItem.links ? firstItem : undefined;
   }
 
   static isAvailableOnline(item: ApiItem) {


### PR DESCRIPTION

### This PR does the following:
- Fixes errors for edition and work pages related to updates on the backend where editions are no longer passing an items object 

### Testing requirements & instructions: 
-  
