### PR TITLE
SFR-1568: Update release github action

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -19,22 +19,23 @@ jobs:
       - name: Tag
         id: autotagger
         uses: butlerlogic/action-autotag@stable
-        with:
+        env: 
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
           strategy: package
-          prefix: v
+          tag_prefix: v
           # use the body of the PR commit as the tag message
           tag_message: ${{ github.event.pull_request.body }}
 
       - name: Release
         id: create_release
         if: steps.autotagger.outputs.tagname != ''
-        uses: actions/create-release@v1.0.0
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.autotagger.outputs.tagname }}
-          release_name: ${{ steps.autotagger.outputs.tagname }}
+          name: ${{ steps.autotagger.outputs.tagname }}
           # use the body of the PR commit as the release body
           body: ${{ github.event.pull_request.body }}
           draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Pre-release]
 
 - SFR-1917: Fixed failing Playwright tests
+- Update Github Action for release from create-release to action-gh-release
 
 ## [0.18.0]
 


### PR DESCRIPTION
[Jira Ticket](http://jira.nypl.org/browse/SFR-1568)

### This PR does the following:
- Updates Github Action for release from create-release to action-gh-release
- Fixes action-autotag error by declaring GITHUB_TOKEN as an env var

### Testing requirements & instructions: 
-  
