### PR TITLE
SFR-2008/Automate_License_Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGE LOG
 
 ## [Pre-release]
+
 - Fix cut off text on search bar dropdown
 - Fix broken link on the About page
+- SFR-2008: Automate License Page Headers and Sub-Headers
 
 ## [0.18.1]
 
@@ -13,7 +15,7 @@
 - Update README to include production release information
 - Upgrade NYPL Design System to 3.1.1
 - Upgrade Web Reader to 4.3.4
-- Fix issue where 0 character is shown when there are no authors 
+- Fix issue where 0 character is shown when there are no authors
 
 ## [0.18.0]
 

--- a/playwright/features/licensePage.feature
+++ b/playwright/features/licensePage.feature
@@ -1,0 +1,13 @@
+Feature: License Page
+
+    Scenario: As a user I want to verify the headers and subheaders of DRB License Page
+        Given I go to the "license" page
+        Then the "license explanations header" should be displayed
+        Then the "public domain header" should be displayed
+        Then the "public domain us only header" should be displayed
+        Then the "creative commons licenses header" should be displayed
+
+    Scenario: As a user I verify the subheaders of DRB License Page are displayed correctly
+        Given I go to the "license" page
+        Then the "public domain subheader" should be displayed
+        Then the "public domain us only subheader" should be displayed

--- a/playwright/support/mappings.ts
+++ b/playwright/support/mappings.ts
@@ -204,6 +204,17 @@ export const elements = {
     "//a[@href='http://www.nypl.org/help/about-nypl/legal-notices/rules-and-regulations']",
   "about NYPL footer link": "//a[@href='http://www.nypl.org/help/about-nypl']",
   "language footer link": "//a[@href='http://www.nypl.org/language']",
+
+  /** license page locators */
+  "license explanations header": "//h1[text()='License Explanations']",
+  "public domain header": "//h2[text()='Public Domain']",
+  "creative commons licenses header":
+    "//h2[text()='Creative Commons Licenses']",
+  "public domain us only header": "//h2[text()='Public Domain (US Only)']",
+  "public domain subheader":
+    "//p[contains(text(),'Works may be in the public domain in the Unites St')]",
+  "public domain us only subheader":
+    "//p[contains(text(),'Works may be in the public domain in the Unites States')]",
 };
 
 export const inputs = {


### PR DESCRIPTION
[Jira Ticket][(http://jira.nypl.org/browse/SFR-XXX](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2008))

### This PR does the following:
- validates the header and sub-header body of whole License Page of DRB

