### PR TITLE
SFR-2033/verify-nypl-header-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix cut off text on search bar dropdown
 - Fix broken link on the About page
 - SFR-2008: Automate License Page Headers and Sub-Headers
+- SFR-2033: Verify the external NYPL header links of DRB App
 
 ## [0.18.1]
 

--- a/playwright/features/headerLinks.feature
+++ b/playwright/features/headerLinks.feature
@@ -18,17 +18,17 @@ Feature: Header Links
         And the "get help header link" should be displayed
         And the "search header link" should be displayed
 
-           Examples:
-            | DRB                 |
-            | "home"              |
-            | "advanced search"   |
-            | "search results"    |
-            | "item details"      |
-            | "edition details"   |
-            | "collection"        |
-            | "read online"       |
-            | "license"           |
-            | "about"             |  
+        Examples:
+            | DRB               |
+            | "home"            |
+            | "advanced search" |
+            | "search results"  |
+            | "item details"    |
+            | "edition details" |
+            | "collection"      |
+            | "read online"     |
+            | "license"         |
+            | "about"           |
 
     Scenario: As a user I navigate to the Digital Research Books home page and verify the account and search header sub-links and elements are displayed
         Given I go to the "home" page
@@ -36,14 +36,27 @@ Feature: Header Links
         Then the <second header link> should be displayed
 
         Examples:
-            | first header link         | second header link                       |
-            | "my account header link"  | "catalog header link"                    |
-            | "my account header link"  | "research catalog header link"           |
-            | "my account header link"  | "close my account header link"           |
-            | "search header link"      | "search header label"                    |
-            | "search header link"      | "search header text field"               |
-            | "search header link"      | "search books music movies radio button" |
-            | "search header link"      | "search research catalog radio button"   |
-            | "search header link"      | "search library website radio button"    |
-            | "search header link"      | "search header button"                   |
-            | "search header link"      | "close search header link"               |
+            | first header link        | second header link                       |
+            | "my account header link" | "catalog header link"                    |
+            | "my account header link" | "research catalog header link"           |
+            | "my account header link" | "close my account header link"           |
+            | "search header link"     | "search header label"                    |
+            | "search header link"     | "search header text field"               |
+            | "search header link"     | "search books music movies radio button" |
+            | "search header link"     | "search research catalog radio button"   |
+            | "search header link"     | "search library website radio button"    |
+            | "search header link"     | "search header button"                   |
+            | "search header link"     | "close search header link"               |
+
+    Scenario: As a user when I click on Locations I should be directed to NYPL location page
+        Given I go to the "home" page
+        Then I click the <first header link>
+        And the <landing page header> should be displayed
+
+        Examples:
+            | first header link           | landing page header              |
+            | "locations header link"     | "locations page header"          |
+            | "library card header link"  | "get a library card page header" |
+            | "email updates header link" | "get email updates page header"  |
+            | "donate header link"        | "donation page button"           |
+            | "shop header link"          | "shop page footer"               |

--- a/playwright/support/mappings.ts
+++ b/playwright/support/mappings.ts
@@ -215,6 +215,14 @@ export const elements = {
     "//p[contains(text(),'Works may be in the public domain in the Unites St')]",
   "public domain us only subheader":
     "//p[contains(text(),'Works may be in the public domain in the Unites States')]",
+
+  /** external page locators */
+  "locations page header":
+    "//div[contains(text(),'Welcome to The New York Public Library. Discover o')]",
+  "get a library card page header": "//h1[@id='hero-banner']",
+  "get email updates page header": "//h1[@id='page-title']",
+  "donation page button": "//button[text()='Donate']",
+  "shop page footer": "//h2[text()='All Proceeds Support the Library']",
 };
 
 export const inputs = {


### PR DESCRIPTION
[Jira Ticket](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2033)

### This PR does the following:
- verifies the external NYPL app links nested inside DRB app
- verifies when clicked on the links user is directed to the correct landing pages.
