### PR TITLE
SFR-2032: Update local API url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix broken link on the About page
 - SFR-2008: Automate License Page Headers and Sub-Headers
 - SFR-2033: Verify the external NYPL header links of DRB App
+- SFR-2032: Update local API url
 
 ## [0.18.1]
 

--- a/config/appConfig.ts
+++ b/config/appConfig.ts
@@ -7,7 +7,7 @@ const appConfig = {
   baseUrl: "",
   api: {
     url: {
-      local: "localhost:5000",
+      local: "http://localhost:5050",
       development: "https://drb-api-qa.nypl.org",
       qa: "https://drb-api-qa.nypl.org",
       production: "http://drb-api-qa.nypl.org",


### PR DESCRIPTION
[Jira Ticket](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2032)

### This PR does the following:
- Updates the local API url to http://localhost:5050
- 5050 is based on the the docker-compose.yml [file](https://github.com/NYPL/drb-etl-pipeline/blob/main/docker-compose.yml#L59) in the ETL pipeline

### Testing requirements & instructions: 
- No testing required. This is just an app config change.
