### PR TITLE
NO-REF: Pin butlerlogic/action-autotag version

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -18,8 +18,8 @@ jobs:
         # the tag will match the package.json version (eg. v1.0.0)
       - name: Tag
         id: autotagger
-        uses: butlerlogic/action-autotag@stable
-        env: 
+        uses: butlerlogic/action-autotag@1.1.2
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           strategy: package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - SFR-2032: Update local API url
 - SFR-2076: Fix DRB PW Regression Tests
 - Update README with instructions to run app locally
+- Update `butlerlogic/action-autotag` version to be pinned since the stable version is using an unsupported Node version
 
 ## [0.18.1]
 


### PR DESCRIPTION
### This PR does the following:
- Pins the `butlerlogic/action-autotag` version to 1.1.2 since the stable version is using an unsupported version of Node.js

### Testing requirements & instructions: 
-  
