### PR TITLE
NO-REF: Hot fix - check if collection groups is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGE LOG
 
+## Unreleased
+
+- Fix error when collections are empty
+
 ## [0.18.2]
 
 - Fix cut off text on search bar dropdown

--- a/src/components/CollectionList/CollectionList.tsx
+++ b/src/components/CollectionList/CollectionList.tsx
@@ -26,7 +26,7 @@ export const CollectionList: React.FC<{ collections: Opds2Feed }> = ({
 
   return (
     <Box>
-      {collections ? (
+      {collections && collections.groups ? (
         <>
           <SimpleGrid gap="grid.l" columns={numberOfColumns}>
             {collections.groups.map((collection, index) => {


### PR DESCRIPTION
### This PR does the following:
- Checks if the collection groups is defined before mapping the data to display the list of collections
