### PR TITLE
SFR-2196: Fix issue with New Relic and standalone Next.js server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ COPY --from=builder /app/public ./public
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/newrelic.js ./newrelic.js
 
 USER nextjs
 


### PR DESCRIPTION
[Jira Ticket](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2196)

### This PR does the following:
- Fixes issue where `docker run` does not find newrelic.js file. Copies the newrelic.js file for running the Next.js standalone server.

### Testing requirements & instructions: 
-  
