### PR TITLE
SFR-2196: Expose New Relic env vars for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,12 @@ ENV APP_ENV $APP_ENV
 FROM base AS runner
 WORKDIR /app
 
+# We need to expose these ARG again, they are needed for browser monitor
+ARG NEW_RELIC_APP_NAME
+ARG NEW_RELIC_LICENSE_KEY
+ENV NEW_RELIC_APP_NAME $NEW_RELIC_APP_NAME
+ENV NEW_RELIC_LICENSE_KEY $NEW_RELIC_LICENSE_KEY
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 const path = require("path");
 
+const nrExternals = require("newrelic/load-externals");
+
 /**
  * @type {import('next').NextConfig}
  */
@@ -23,6 +25,11 @@ const nextConfig = {
         };
       }
     }
+
+    // In order for newrelic to effectively instrument a Next.js application,
+    // the modules that newrelic supports should not be mangled by webpack. Thus,
+    // we need to "externalize" all of the modules that newrelic supports.
+    config = nrExternals(config);
 
     return config;
   },


### PR DESCRIPTION
[Jira Ticket](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2196)

### This PR does the following:
- Expose New Relic env vars for runtime and update next.config.js to externalize thrid party libraries as per the official [newrelic example](https://github.com/newrelic/newrelic-node-examples/blob/main/nextjs/nextjs-app-router/next.config.js)

### Testing requirements & instructions: 
-  
