### PR TITLE
SFR: 2257 - fix pw tests for license page changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update License page to Copyright and add section for "In Copyright" explanation
 - Remove error codes from error page
 - Update styling for mobile view of error page
+- SFR:2257 - fix pw tests for modified license page
 
 ## [0.18.3]
 

--- a/playwright/features/copyrightPage.feature
+++ b/playwright/features/copyrightPage.feature
@@ -1,13 +1,13 @@
 Feature: License Page
 
-    Scenario: As a user I want to verify the headers and subheaders of DRB License Page
-        Given I go to the "license" page
-        Then the "license explanations header" should be displayed
+    Scenario: As a user I want to verify the headers and subheaders of DRB Copyright Page
+        Given I go to the "copyright" page
+        Then the "copyright explanations header" should be displayed
         Then the "public domain header" should be displayed
         Then the "public domain us only header" should be displayed
         Then the "creative commons licenses header" should be displayed
 
-    Scenario: As a user I verify the subheaders of DRB License Page are displayed correctly
-        Given I go to the "license" page
+    Scenario: As a user I verify the subheaders of DRB Copyright Page are displayed correctly
+        Given I go to the "copyright" page
         Then the "public domain subheader" should be displayed
         Then the "public domain us only subheader" should be displayed

--- a/playwright/features/drbFooters.feature
+++ b/playwright/features/drbFooters.feature
@@ -15,13 +15,13 @@ Feature: Footer Links
         And the "language footer link" should be displayed
 
         Examples:
-        | DRB                 |
-        | "home"              |
-        | "advanced search"   |
-        | "search results"    |
-        | "item details"      |
-        | "edition details"   |
-        | "collection"        |
-        | "read online"       |
-        | "license"           |
-        | "about"             |
+            | DRB               |
+            | "home"            |
+            | "advanced search" |
+            | "search results"  |
+            | "item details"    |
+            | "edition details" |
+            | "collection"      |
+            | "read online"     |
+            | "copyright"       |
+            | "about"           |

--- a/playwright/features/headerLinks.feature
+++ b/playwright/features/headerLinks.feature
@@ -27,7 +27,7 @@ Feature: Header Links
             | "edition details" |
             | "collection"      |
             | "read online"     |
-            | "license"         |
+            | "copyright"       |
             | "about"           |
 
     Scenario: As a user I navigate to the Digital Research Books home page and verify the account and search header sub-links and elements are displayed

--- a/playwright/support/mappings.ts
+++ b/playwright/support/mappings.ts
@@ -213,7 +213,7 @@ export const elements = {
   "language footer link": "//a[@href='http://www.nypl.org/language']",
 
   /** license page locators */
-  "license explanations header": "//h1[text()='License Explanations']",
+  "copyright explanations header": "//h1[text()='Copyright Explanations']",
   "public domain header": "//h2[text()='Public Domain']",
   "creative commons licenses header":
     "//h2[text()='Creative Commons Licenses']",


### PR DESCRIPTION
[Jira Ticket](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2257)

### This PR does the following:
- updates the license page to copywright page for PW tests
- updates the name licensePage.feature to copyrightPage.feature
- updates the mapping related to license page headers and subheaders

