### PR TITLE
NOREF prepare 0.18.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGE LOG
 
-## [Prerelease]
+## [0.18.5]
 - Make NYPL footer sticky
 
 ## [0.18.4]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
[SFR-2279](https://newyorkpubliclibrary.atlassian.net/browse/SFR-2279)

### This PR does the following:
- Upgrades version to 0.18.5 to prepare for the release


[SFR-2279]: https://newyorkpubliclibrary.atlassian.net/browse/SFR-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ