### PR TITLE
Release 0.18.7 to production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGE LOG
 
 ## [Prerelease]
+
+## [0.18.7]
 - Fix header when banner is up
 
 ## [0.18.6]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGE LOG
 
 ## [Prerelease]
+- Fix header when banner is up
 
 ## [0.18.6]
 - Add submit feedback error handling and new fields

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -27,7 +27,7 @@ class MyDocument extends Document<DocumentProps> {
             minHeight: "100vh",
           }}
         >
-          <div id="nypl-header"></div>
+          <div id="nypl-header" style={{ flexShrink: 0 }}></div>
           <Script
             src="https://ds-header.nypl.org/header.min.js?containerId=nypl-header"
             strategy="beforeInteractive"


### PR DESCRIPTION
[NO-REF: Fix header when banner is up](https://github.com/NYPL/sfr-bookfinder-front-end/commit/1ac22ee5431512f1365b8a97210138dff4099dc7)