### PR TITLE
NO-REF prepare 0.18.8 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGE LOG
 
-## [Prerelease]
+## [0.18.8]
 
 - Add survey banner to Landing, Collection, Edition, Work, and Search pages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sfr-bookfinder-front-end",
-      "version": "0.18.4",
+      "version": "0.18.8",
       "dependencies": {
         "@chakra-ui/react": "2.5.4",
         "@newrelic/next": "0.10.0",
@@ -18,7 +18,7 @@
         "extract-loader": "^5.1.0",
         "file-loader": "^6.2.0",
         "focus-trap-react": "^10.0.0",
-        "newrelic": "^12.5.0",
+        "newrelic": "12.5.0",
         "next": "^13.5.6",
         "next-transpile-modules": "^7.0.0",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
### This PR does the following:
- Updates version to 0.18.8

### Testing requirements & instructions: 
-  
