### PR TITLE
NO-REF: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Each line is a file pattern followed by one or more owners. These owners will be the default owners for everything in the repo. Unless a later match takes precedence,e ach owner will be requested for review when someone opens a pull request.
-* @samanthaandrews @jackiequach @kristojorg @Toxiapo @oliviawongnyc
+* @samanthaandrews @jackiequach @kylevillegas93

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Prerelease]
 
+- Remove Kristo, Jiayong, and Olivia and add Kyle as codeowners
+
 ## [0.18.9]
 
 - Enable playwright tests GH action


### PR DESCRIPTION
### This PR does the following:
- Remove Kristo, Jiayong, and Olivia and add Kyle as codeowner

### Testing requirements & instructions: 
-  
