### PR TITLE
SFR-2396: Deploy to new terraform ECS cluster

### DIFF
--- a/.github/workflows/build-production.yaml
+++ b/.github/workflows/build-production.yaml
@@ -86,3 +86,7 @@ jobs:
       - name: Force ECS Update
         run: |
           aws ecs update-service --cluster sfr-front-end-production --service sfr-front-end-production --force-new-deployment
+
+      - name: Force ECS Update - Terraform
+        run: |
+            aws ecs update-service --cluster sfr-frontend-production-tf --service sfr-frontend-production-tf --force-new-deployment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Prerelease]
 
 - Remove Kristo, Jiayong, and Olivia and add Kyle as codeowners
+- Deploy to new Terraform ECS cluster in production
 
 ## [0.18.9]
 


### PR DESCRIPTION
[Jira Ticket](https://newyorkpubliclibrary.atlassian.net/jira/software/c/projects/SFR/boards/130?assignee=712020%3A4ff7b903-7103-4b3d-ada8-a9e78f8b4aff)

### This PR does the following:
- Deploys frontend changes to the TF production ECS cluster 
