### PR TITLE
NO-REF prepare 0.18.10 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Prerelease]
 
+## [0.18.10]
+
 - Remove Kristo, Jiayong, and Olivia and add Kyle as codeowners
 - Deploy to new Terraform ECS cluster in production
 - Deploy only to the new Terraform ECS clusters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sfr-bookfinder-front-end",
-      "version": "0.18.9",
+      "version": "0.18.10",
       "dependencies": {
         "@chakra-ui/react": "2.5.4",
         "@newrelic/next": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sfr-bookfinder-front-end",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
### This PR does the following:
- Updates version to 0.18.10

### Testing requirements & instructions: 
-  
